### PR TITLE
revert(eslint-plugin-mark): partially revert #134 due to performance regression

### DIFF
--- a/packages/eslint-plugin-mark/src/rules/allowed-heading/allowed-heading.js
+++ b/packages/eslint-plugin-mark/src/rules/allowed-heading/allowed-heading.js
@@ -150,21 +150,21 @@ export default {
 
   create(context) {
     const [{ h1, h2, h3, h4, h5, h6 }] = context.options;
-    const headingMap = new Map([
-      [1, h1],
-      [2, h2],
-      [3, h3],
-      [4, h4],
-      [5, h5],
-      [6, h6],
-    ]);
+    const headingMap = {
+      1: h1,
+      2: h2,
+      3: h3,
+      4: h4,
+      5: h5,
+      6: h6,
+    };
 
     return {
       heading(node) {
         const actualHeadingText = context.sourceCode
           .getText(node)
           .replace(headingRegex, '');
-        const expectedHeadingTexts = headingMap.get(node.depth);
+        const expectedHeadingTexts = headingMap[node.depth];
 
         if (expectedHeadingTexts === false) return;
 


### PR DESCRIPTION
This pull request includes a change to simplify the data structure used for mapping heading levels to their allowed texts in the `allowed-heading` ESLint rule.

Codebase simplification:

* [`packages/eslint-plugin-mark/src/rules/allowed-heading/allowed-heading.js`](diffhunk://#diff-d5951c4773cae305a950c0c4cc9ccb7ae0edd097899fe6b6a095e19a15c7f34fL153-R167): Replaced the `Map` object with a plain JavaScript object (`{}`) for the `headingMap` variable, simplifying access to allowed heading texts by using direct property access (`headingMap[node.depth]`) instead of the `Map.get()` method.