### PR TITLE
chore(deps-dev): bump `textlint-rule-allowed-uris`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "prettier": "^3.6.2",
         "prettier-config-bananass": "^0.3.0",
         "textlint": "^14.7.2",
-        "textlint-rule-allowed-uris": "^1.1.1",
+        "textlint-rule-allowed-uris": "^2.0.0",
         "typescript": "^5.8.3"
       },
       "engines": {
@@ -2295,39 +2295,11 @@
       }
     },
     "node_modules/@keyv/serialize": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.0.3.tgz",
-      "integrity": "sha512-qnEovoOp5Np2JDGonIDL6Ayihw0RhnRh6vxPuHo4RDn1UOzwEo4AeIfpL6UGIrsceWrCMiVPgwRjbHu4vYFc3g==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.0.tgz",
+      "integrity": "sha512-RlDgexML7Z63Q8BSaqhXdCYNBy/JQnqYIwxofUrNLGCblOMHp+xux2Q8nLMLlPpgHQPoU0Do8Z6btCpRBEqZ8g==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^6.0.3"
-      }
-    },
-    "node_modules/@keyv/serialize/node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
+      "license": "MIT"
     },
     "node_modules/@lerna/create": {
       "version": "8.2.2",
@@ -6095,24 +6067,24 @@
       "license": "ISC"
     },
     "node_modules/cacheable": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-1.10.0.tgz",
-      "integrity": "sha512-SSgQTAnhd7WlJXnGlIi4jJJOiHzgnM5wRMEPaXAU4kECTAMpBoYKoZ9i5zHmclIEZbxcu3j7yY/CF8DTmwIsHg==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-1.10.3.tgz",
+      "integrity": "sha512-M6p10iJ/VT0wT7TLIGUnm958oVrU2cUK8pQAVU21Zu7h8rbk/PeRtRWrvHJBql97Bhzk3g1N6+2VKC+Rjxna9Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "hookified": "^1.8.2",
-        "keyv": "^5.3.3"
+        "hookified": "^1.10.0",
+        "keyv": "^5.4.0"
       }
     },
     "node_modules/cacheable/node_modules/keyv": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.3.4.tgz",
-      "integrity": "sha512-ypEvQvInNpUe+u+w8BIcPkQvEqXquyyibWE/1NB5T2BTzIpS5cGEV1LZskDzPSTvNAaT4+5FutvzlvnkxOSKlw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.4.0.tgz",
+      "integrity": "sha512-TMckyVjEoacG5IteUpUrOBsFORtheqziVyyY2dLUwg1jwTb8u48LX4TgmtogkNl9Y9unaEJ1luj10fGyjMGFOQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@keyv/serialize": "^1.0.3"
+        "@keyv/serialize": "^1.1.0"
       }
     },
     "node_modules/call-bind": {
@@ -6326,9 +6298,9 @@
       }
     },
     "node_modules/cheerio": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.1.1.tgz",
-      "integrity": "sha512-bTXxVZeOfc3I97S4CSYVjcYvaTp92YOlwEUrVRtYrkuVn7S8/QKnnozVlztPcXlU039S2UxtsjAMyFRbX3V9gQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.1.2.tgz",
+      "integrity": "sha512-IkxPpb5rS/d1IiLbHMgfPuS0FgiWTtFIm/Nj+2woXDLTZ7fOT2eqzgYbdMlLweqlHbsZjxEChoVK+7iph7jyQg==",
       "license": "MIT",
       "dependencies": {
         "cheerio-select": "^2.1.0",
@@ -6340,7 +6312,7 @@
         "parse5": "^7.3.0",
         "parse5-htmlparser2-tree-adapter": "^7.1.0",
         "parse5-parser-stream": "^7.1.2",
-        "undici": "^7.11.0",
+        "undici": "^7.12.0",
         "whatwg-mimetype": "^4.0.0"
       },
       "engines": {
@@ -9770,9 +9742,9 @@
       "license": "MIT"
     },
     "node_modules/hookified": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.10.0.tgz",
-      "integrity": "sha512-dJw0492Iddsj56U1JsSTm9E/0B/29a1AuoSLRAte8vQg/kaTGF3IgjEWT8c8yG4cC10+HisE1x5QAwR0Xwc+DA==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.11.0.tgz",
+      "integrity": "sha512-aDdIN3GyU5I6wextPplYdfmWCo+aLmjjVbntmX6HLD5RCi/xKsivYEBhnRD+d9224zFf008ZpLMPlWF0ZodYZw==",
       "dev": true,
       "license": "MIT"
     },
@@ -11386,9 +11358,9 @@
       }
     },
     "node_modules/libnpmpublish/node_modules/ci-info": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.2.0.tgz",
-      "integrity": "sha512-cYY9mypksY8NRqgDB1XD1RiJL338v/551niynFTGkZOO2LHuB2OmOYxDIe/ttN9AHwrqdum1360G3ald0W9kCg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.0.tgz",
+      "integrity": "sha512-l+2bNRMiQgcfILUi33labAZYIWlH1kWDp+ecNo5iisRKrbm0xcRyCww71/YU0Fkw0mAFpz9bJayXPjey6vkmaQ==",
       "dev": true,
       "funding": [
         {
@@ -12940,9 +12912,9 @@
       }
     },
     "node_modules/mdast-util-to-hast/node_modules/vfile-message": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.2.tgz",
-      "integrity": "sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -16183,9 +16155,9 @@
       }
     },
     "node_modules/pkg-types": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.1.1.tgz",
-      "integrity": "sha512-eY0QFb6eSwc9+0d/5D2lFFUq+A3n3QNGSy/X2Nvp+6MfzGw2u6EbA7S80actgjY1lkvvI0pqB+a4hioMh443Ew==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.2.0.tgz",
+      "integrity": "sha512-2SM/GZGAEkPp3KWORxQZns4M+WSeXbC2HEvmOIJe3Cmiv6ieAJvdVhDldtHqM5J1Y7MrR1XhkBT/rMlhh9FdqQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -18470,65 +18442,41 @@
       }
     },
     "node_modules/textlint-rule-allowed-uris": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/textlint-rule-allowed-uris/-/textlint-rule-allowed-uris-1.1.1.tgz",
-      "integrity": "sha512-GzvfUeeXn+c+24PYe3MKEufHjyi3jqjfgmjE/s511dOLuEL7MagQdQuMEuMHE7b0dBN0dB9Z3XgA5lu5unazQA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/textlint-rule-allowed-uris/-/textlint-rule-allowed-uris-2.0.0.tgz",
+      "integrity": "sha512-KfGajAuDs4fPnujxEi4rNtSds7s4LYg+YWiw5sToY+H/FChYp8XINoRWL6s/evaOAPvjNqmEJaJeVfymRRuNnQ==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
         "."
       ],
       "dependencies": {
-        "cheerio": "^1.0.0",
-        "mime-types": "^3.0.1"
+        "cheerio": "^1.1.2"
       },
       "peerDependencies": {
-        "textlint": "^14.0.4"
-      }
-    },
-    "node_modules/textlint-rule-allowed-uris/node_modules/mime-db": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/textlint-rule-allowed-uris/node_modules/mime-types": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
-      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "^1.54.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
+        "textlint": "^14.0.0 || ^15.0.0"
       }
     },
     "node_modules/textlint/node_modules/file-entry-cache": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-10.1.1.tgz",
-      "integrity": "sha512-zcmsHjg2B2zjuBgjdnB+9q0+cWcgWfykIcsDkWDB4GTPtl1eXUA+gTI6sO0u01AqK3cliHryTU55/b2Ow1hfZg==",
+      "version": "10.1.3",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-10.1.3.tgz",
+      "integrity": "sha512-D+w75Ub8T55yor7fPgN06rkCAUbAYw2vpxJmmjv/GDAcvCnv9g7IvHhIZoxzRZThrXPFI2maeY24pPbtyYU7Lg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "flat-cache": "^6.1.10"
+        "flat-cache": "^6.1.12"
       }
     },
     "node_modules/textlint/node_modules/flat-cache": {
-      "version": "6.1.10",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.10.tgz",
-      "integrity": "sha512-B6/v1f0NwjxzmeOhzfXPGWpKBVA207LS7lehaVKQnFrVktcFRfkzjZZ2gwj2i1TkEUMQht7ZMJbABUT5N+V1Nw==",
+      "version": "6.1.12",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.12.tgz",
+      "integrity": "sha512-U+HqqpZPPXP5d24bWuRzjGqVqUcw64k4nZAbruniDwdRg0H10tvN7H6ku1tjhA4rg5B9GS3siEvwO2qjJJ6f8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cacheable": "^1.10.0",
+        "cacheable": "^1.10.3",
         "flatted": "^3.3.3",
-        "hookified": "^1.9.1"
+        "hookified": "^1.10.0"
       }
     },
     "node_modules/textlint/node_modules/hosted-git-info": {
@@ -18824,9 +18772,9 @@
       }
     },
     "node_modules/ts-declaration-location/node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -19131,9 +19079,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.11.0.tgz",
-      "integrity": "sha512-heTSIac3iLhsmZhUCjyS3JQEkZELateufzZuBaVM5RHXdSBMb1LPMQf5x+FH7qjsZYDP0ttAc3nnVpUB+wYbOg==",
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.12.0.tgz",
+      "integrity": "sha512-GrKEsc3ughskmGA9jevVlIOPMiiAHJ4OFUtaAH+NhfTUSiZ1wMPIQqQvAJUrJspFXJt3EBWgpAeoHEDVT1IBug==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "prettier": "^3.6.2",
     "prettier-config-bananass": "^0.3.0",
     "textlint": "^14.7.2",
-    "textlint-rule-allowed-uris": "^1.1.1",
+    "textlint-rule-allowed-uris": "^2.0.0",
     "typescript": "^5.8.3"
   }
 }


### PR DESCRIPTION
This pull request updates a dependency in the `package.json` file to use the latest version.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L55-R55): Upgraded `textlint-rule-allowed-uris` from version `^1.1.1` to `^2.0.0`.