### PR TITLE
chore(*): update `dependabot` and `vscode/settings`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,11 @@ updates:
     commit-message:
       prefix: 'chore'
       include: 'scope'
+    cooldown:
+      default-days: 7
+      semver-major-days: 45
+      semver-minor-days: 15
+      semver-patch-days: 7
     # Specify all directories from the current layer and below recursively, using globstar, for locations of manifest files.
     directories:
       - '**/*'
@@ -45,6 +50,8 @@ updates:
     commit-message:
       prefix: 'chore'
       include: 'scope'
+    cooldown:
+      default-days: 15
     # Workflow files stored in the default location of `.github/workflows`. (You don't need to specify `/.github/workflows` for `directory`. You can use `directory: "/"`.)
     directory: '/'
     open-pull-requests-limit: 2

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,6 +10,29 @@
     "source.fixAll.stylelint": "always",
     "source.fixAll.markdownlint": "always"
   },
+  "eslint.validate": [
+    "html",
+    "md",
+    "mdx",
+    "css",
+    "scss",
+    "js",
+    "mjs",
+    "cjs",
+    "jsx",
+    "ts",
+    "mts",
+    "cts",
+    "tsx",
+    "json",
+    "jsonc",
+    "json5",
+    "javascript",
+    "javascriptreact",
+    "typescript",
+    "typescriptreact",
+    "markdown"
+  ],
   "stylelint.validate": ["css", "scss"],
   "C_Cpp.clang_format_fallbackStyle": "Google"
 }


### PR DESCRIPTION
This pull request introduces configuration improvements for both Dependabot and the VSCode development environment. The most significant changes are the addition of cooldown periods for automated dependency updates and the expansion of ESLint validation to cover more file types.

**Dependabot configuration enhancements:**

* Added cooldown periods to the `updates` section in `.github/dependabot.yml`, specifying different wait times before Dependabot opens new PRs for major (45 days), minor (15 days), and patch (7 days) semantic version updates, with a default of 7 or 15 days depending on the directory. [[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R10-R14) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R53-R54)

**VSCode settings improvements:**

* Expanded the `eslint.validate` array in `.vscode/settings.json` to include a wide range of file types, ensuring ESLint checks are run on HTML, Markdown, CSS, JavaScript, TypeScript, JSON, and related file extensions.