### PR TITLE
chore(eslint-plugin-mark): bump `@eslint/markdown` to `7.5.0`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1261,10 +1261,23 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@eslint/json/node_modules/@eslint/core": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.2.tgz",
+      "integrity": "sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
     "node_modules/@eslint/markdown": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/@eslint/markdown/-/markdown-7.4.1.tgz",
-      "integrity": "sha512-fhcQcylVqgb7GLPr2+6hlDQXK4J3d/fPY6qzk9/i7IYtQkIr15NKI5Zg39Dv2cV/bn5J0Znm69rmu9vJI/7Tlw==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@eslint/markdown/-/markdown-7.5.0.tgz",
+      "integrity": "sha512-reKloVSpytg4ene3yviPJcUO7zglpNn9kWNRiSQ/8gBbBFMKW5Q042LaCi3wv2vVtbPNnLrl6WvhRAHeBd43QA==",
       "license": "MIT",
       "workspaces": [
         "examples/*"
@@ -1696,6 +1709,19 @@
       "dependencies": {
         "@eslint/core": "^0.15.2",
         "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.2.tgz",
+      "integrity": "sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2519,13 +2545,13 @@
       "license": "MIT"
     },
     "node_modules/@shikijs/core": {
-      "version": "3.12.3",
-      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.12.3.tgz",
-      "integrity": "sha512-PPCwgF8HThjLcTTr9J64gBu0U5jKS4NoFNCmZJeVXw1i+6Kf9V3HJFBNUEGTHY2izeeVnF+vHXVo5n5YcEWj+Q==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.13.0.tgz",
+      "integrity": "sha512-3P8rGsg2Eh2qIHekwuQjzWhKI4jV97PhvYjYUzGqjvJfqdQPz+nMlfWahU24GZAyW1FxFI1sYjyhfh5CoLmIUA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.12.3",
+        "@shikijs/types": "3.13.0",
         "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4",
         "hast-util-to-html": "^9.0.5"
@@ -2543,17 +2569,6 @@
         "oniguruma-to-es": "^4.3.3"
       }
     },
-    "node_modules/@shikijs/engine-javascript/node_modules/@shikijs/types": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.13.0.tgz",
-      "integrity": "sha512-oM9P+NCFri/mmQ8LoFGVfVyemm5Hi27330zuOBp0annwJdKH1kOLndw3zCtAVDehPLg9fKqoEx3Ht/wNZxolfw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/vscode-textmate": "^10.0.2",
-        "@types/hast": "^3.0.4"
-      }
-    },
     "node_modules/@shikijs/engine-oniguruma": {
       "version": "3.13.0",
       "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.13.0.tgz",
@@ -2563,17 +2578,6 @@
       "dependencies": {
         "@shikijs/types": "3.13.0",
         "@shikijs/vscode-textmate": "^10.0.2"
-      }
-    },
-    "node_modules/@shikijs/engine-oniguruma/node_modules/@shikijs/types": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.13.0.tgz",
-      "integrity": "sha512-oM9P+NCFri/mmQ8LoFGVfVyemm5Hi27330zuOBp0annwJdKH1kOLndw3zCtAVDehPLg9fKqoEx3Ht/wNZxolfw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/vscode-textmate": "^10.0.2",
-        "@types/hast": "^3.0.4"
       }
     },
     "node_modules/@shikijs/langs": {
@@ -2586,17 +2590,6 @@
         "@shikijs/types": "3.13.0"
       }
     },
-    "node_modules/@shikijs/langs/node_modules/@shikijs/types": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.13.0.tgz",
-      "integrity": "sha512-oM9P+NCFri/mmQ8LoFGVfVyemm5Hi27330zuOBp0annwJdKH1kOLndw3zCtAVDehPLg9fKqoEx3Ht/wNZxolfw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/vscode-textmate": "^10.0.2",
-        "@types/hast": "^3.0.4"
-      }
-    },
     "node_modules/@shikijs/themes": {
       "version": "3.13.0",
       "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.13.0.tgz",
@@ -2607,26 +2600,15 @@
         "@shikijs/types": "3.13.0"
       }
     },
-    "node_modules/@shikijs/themes/node_modules/@shikijs/types": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.13.0.tgz",
-      "integrity": "sha512-oM9P+NCFri/mmQ8LoFGVfVyemm5Hi27330zuOBp0annwJdKH1kOLndw3zCtAVDehPLg9fKqoEx3Ht/wNZxolfw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/vscode-textmate": "^10.0.2",
-        "@types/hast": "^3.0.4"
-      }
-    },
     "node_modules/@shikijs/transformers": {
-      "version": "3.12.3",
-      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-3.12.3.tgz",
-      "integrity": "sha512-EBGWYdmlUFzonSQMEnPn7pmBoT7vLHk8umeLAizR7oJ5dIFTfPi5/yGNAduU0VVVI+wH1yq6EGFlyDcTn5QdGQ==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-3.13.0.tgz",
+      "integrity": "sha512-833lcuVzcRiG+fXvgslWsM2f4gHpjEgui1ipIknSizRuTgMkNZupiXE5/TVJ6eSYfhNBFhBZKkReKWO2GgYmqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@shikijs/core": "3.12.3",
-        "@shikijs/types": "3.12.3"
+        "@shikijs/core": "3.13.0",
+        "@shikijs/types": "3.13.0"
       }
     },
     "node_modules/@shikijs/twoslash": {
@@ -2644,34 +2626,10 @@
         "typescript": ">=5.5.0"
       }
     },
-    "node_modules/@shikijs/twoslash/node_modules/@shikijs/core": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.13.0.tgz",
-      "integrity": "sha512-3P8rGsg2Eh2qIHekwuQjzWhKI4jV97PhvYjYUzGqjvJfqdQPz+nMlfWahU24GZAyW1FxFI1sYjyhfh5CoLmIUA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/types": "3.13.0",
-        "@shikijs/vscode-textmate": "^10.0.2",
-        "@types/hast": "^3.0.4",
-        "hast-util-to-html": "^9.0.5"
-      }
-    },
-    "node_modules/@shikijs/twoslash/node_modules/@shikijs/types": {
+    "node_modules/@shikijs/types": {
       "version": "3.13.0",
       "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.13.0.tgz",
       "integrity": "sha512-oM9P+NCFri/mmQ8LoFGVfVyemm5Hi27330zuOBp0annwJdKH1kOLndw3zCtAVDehPLg9fKqoEx3Ht/wNZxolfw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/vscode-textmate": "^10.0.2",
-        "@types/hast": "^3.0.4"
-      }
-    },
-    "node_modules/@shikijs/types": {
-      "version": "3.12.3",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.12.3.tgz",
-      "integrity": "sha512-spl99dj9qzPcTvYJLhfp6Zw0umQMNN8q3hXo0tbTTylxXtu5Uiy9WLRhuv2P/g+njFd/lSZU7HnctXuxiwEAwg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11908,30 +11866,6 @@
         "@types/hast": "^3.0.4"
       }
     },
-    "node_modules/shiki/node_modules/@shikijs/core": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.13.0.tgz",
-      "integrity": "sha512-3P8rGsg2Eh2qIHekwuQjzWhKI4jV97PhvYjYUzGqjvJfqdQPz+nMlfWahU24GZAyW1FxFI1sYjyhfh5CoLmIUA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/types": "3.13.0",
-        "@shikijs/vscode-textmate": "^10.0.2",
-        "@types/hast": "^3.0.4",
-        "hast-util-to-html": "^9.0.5"
-      }
-    },
-    "node_modules/shiki/node_modules/@shikijs/types": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.13.0.tgz",
-      "integrity": "sha512-oM9P+NCFri/mmQ8LoFGVfVyemm5Hi27330zuOBp0annwJdKH1kOLndw3zCtAVDehPLg9fKqoEx3Ht/wNZxolfw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/vscode-textmate": "^10.0.2",
-        "@types/hast": "^3.0.4"
-      }
-    },
     "node_modules/side-channel": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
@@ -14119,7 +14053,7 @@
       "version": "0.1.0-canary.8",
       "license": "MIT",
       "dependencies": {
-        "@eslint/markdown": "^7.4.1",
+        "@eslint/markdown": "^7.5.0",
         "emoji-regex": "^10.6.0",
         "parse5": "^8.0.0"
       },
@@ -14150,7 +14084,7 @@
     "website": {
       "devDependencies": {
         "@codecov/vite-plugin": "^1.9.1",
-        "@shikijs/transformers": "^3.12.3",
+        "@shikijs/transformers": "^3.13.0",
         "@shikijs/vitepress-twoslash": "^3.13.0",
         "eslint-plugin-mark": "^0.1.0-canary.8",
         "markdown-it-footnote": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -54,10 +54,5 @@
     "textlint": "14.7.2",
     "textlint-rule-allowed-uris": "^2.0.1",
     "typescript": "^5.9.3"
-  },
-  "overrides": {
-    "@eslint/json": {
-      "@eslint/core": "^0.16.0"
-    }
   }
 }

--- a/packages/eslint-plugin-mark/package.json
+++ b/packages/eslint-plugin-mark/package.json
@@ -82,7 +82,7 @@
     "eslint": "^9.15.0"
   },
   "dependencies": {
-    "@eslint/markdown": "^7.4.1",
+    "@eslint/markdown": "^7.5.0",
     "emoji-regex": "^10.6.0",
     "parse5": "^8.0.0"
   },

--- a/website/package.json
+++ b/website/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@codecov/vite-plugin": "^1.9.1",
-    "@shikijs/transformers": "^3.12.3",
+    "@shikijs/transformers": "^3.13.0",
     "@shikijs/vitepress-twoslash": "^3.13.0",
     "eslint-plugin-mark": "^0.1.0-canary.8",
     "markdown-it-footnote": "^4.0.0",


### PR DESCRIPTION
This pull request updates several dependencies across the project to their latest versions and removes an unnecessary `overrides` section from the root `package.json`. These changes help keep the codebase up-to-date and simplify dependency management.

**Dependency updates:**

* Upgraded `@eslint/markdown` from version `7.4.1` to `7.5.0` in `packages/eslint-plugin-mark/package.json` to ensure compatibility with the latest markdown linting features.
* Upgraded `@shikijs/transformers` from version `3.12.3` to `3.13.0` in `website/package.json` for improved syntax highlighting and transformer support.

**Package management simplification:**

* Removed the `overrides` section for `@eslint/json` and `@eslint/core` from the root `package.json`, reducing complexity in dependency resolution.