### PR TITLE
docs(website): update rule documentation to include type information for options

### DIFF
--- a/website/docs/rules/no-curly-quote.md
+++ b/website/docs/rules/no-curly-quote.md
@@ -64,25 +64,25 @@ Examples of **correct** code for this rule:
 
 ### `checkLeftDoubleQuotationMark`
 
-> Default: `true`
+> Type: `boolean` / Default: `true`
 
 When `checkLeftDoubleQuotationMark` is set to `false`, this rule will not check for the left double quotation mark (`“`).
 
 ### `checkRightDoubleQuotationMark`
 
-> Default: `true`
+> Type: `boolean` / Default: `true`
 
 When `checkRightDoubleQuotationMark` is set to `false`, this rule will not check for the right double quotation mark (`”`).
 
 ### `checkLeftSingleQuotationMark`
 
-> Default: `true`
+> Type: `boolean` / Default: `true`
 
 When `checkLeftSingleQuotationMark` is set to `false`, this rule will not check for the left single quotation mark (`‘`).
 
 ### `checkRightSingleQuotationMark`
 
-> Default: `true`
+> Type: `boolean` / Default: `true`
 
 When `checkRightSingleQuotationMark` is set to `false`, this rule will not check for the right single quotation mark (`’`).
 

--- a/website/docs/rules/no-double-space.md
+++ b/website/docs/rules/no-double-space.md
@@ -81,7 +81,7 @@ foo bar    <!-- trailing multiple space⁡ -->
 
 ### `checkMultipleSpace`
 
-> Default: `false`
+> Type: `boolean` / Default: `false`
 
 When `checkMultipleSpace` is set to `true`, this rule will also check for multiple consecutive spaces (more than two) within a sentence.
 

--- a/website/docs/rules/no-git-conflict-marker.md
+++ b/website/docs/rules/no-git-conflict-marker.md
@@ -103,6 +103,6 @@ Examples of **correct** code for this rule:
 
 ### `skipCode`
 
-> Default: `true`
+> Type: `boolean` / Default: `true`
 
 `true` allows any Git conflict markers in code blocks.

--- a/website/docs/rules/no-irregular-whitespace.md
+++ b/website/docs/rules/no-irregular-whitespace.md
@@ -174,13 +174,13 @@ Examples of **correct** code for this rule:
 
 ### `skipCode`
 
-> Default: `true`
+> Type: `boolean` / Default: `true`
 
 `true` allows any irregular whitespace in code blocks.
 
 ### `skipInlineCode`
 
-> Default: `true`
+> Type: `boolean` / Default: `true`
 
 `true` allows any irregular whitespace in inline code.
 


### PR DESCRIPTION
This pull request updates the documentation for several linting rules to clarify the type information for their configuration options. Specifically, it adds the type (`boolean`) alongside the default value for each option, making the documentation more precise and consistent.

Documentation improvements for rule options:

* Added explicit type information (`Type: boolean`) to the `checkLeftDoubleQuotationMark`, `checkRightDoubleQuotationMark`, `checkLeftSingleQuotationMark`, and `checkRightSingleQuotationMark` options in `website/docs/rules/no-curly-quote.md`.
* Added explicit type information to the `checkMultipleSpace` option in `website/docs/rules/no-double-space.md`.
* Added explicit type information to the `skipCode` option in `website/docs/rules/no-git-conflict-marker.md`.
* Added explicit type information to the `skipCode` and `skipInlineCode` options in `website/docs/rules/no-irregular-whitespace.md`.