### PR TITLE
fix(eslint-plugin-mark)!: remove `core/constants` export

### DIFF
--- a/packages/eslint-plugin-mark/package.json
+++ b/packages/eslint-plugin-mark/package.json
@@ -8,10 +8,6 @@
       "types": "./build/index.d.ts",
       "default": "./src/index.js"
     },
-    "./core/constants": {
-      "types": "./build/core/constants.d.ts",
-      "default": "./src/core/constants.js"
-    },
     "./package.json": "./package.json"
   },
   "typesVersions": {
@@ -21,9 +17,6 @@
       ],
       ".": [
         "./build/index.d.ts"
-      ],
-      "./core/constants": [
-        "./build/core/constants.d.ts"
       ]
     }
   },

--- a/packages/eslint-plugin-mark/src/core/constants.js
+++ b/packages/eslint-plugin-mark/src/core/constants.js
@@ -12,34 +12,18 @@ import { createRequire } from 'node:module';
 // Declaration
 // --------------------------------------------------------------------------------
 
-/** @type {{ description: string, homepage: string, name: 'eslint-plugin-mark', version: string }} */
-const { description, homepage, name, version } = createRequire(import.meta.url)(
-  '../../package.json',
-);
+/** @type {{ homepage: string, name: 'eslint-plugin-mark', version: string }} */
+const { homepage, name, version } = createRequire(import.meta.url)('../../package.json');
 
 // --------------------------------------------------------------------------------
 // Export
 // --------------------------------------------------------------------------------
 
 /** @satisfies {string} */
-export const PKG_DESCRIPTION = description;
-/** @satisfies {string} */
 export const PKG_NAME = name;
 /** @satisfies {string} */
 export const PKG_VERSION = version;
-/** @satisfies {string} */
-export const PKG_AUTHOR = '루밀LuMir';
-
-/** @satisfies {string} */
-export const URL_HOMEPAGE = homepage;
-/** @satisfies {string} */
-export const URL_GITHUB = `https://github.com/lumirlumir/npm-${PKG_NAME}`;
-/** @satisfies {string} */
-export const URL_NPM = 'https://www.npmjs.com';
-/** @satisfies {string} */
-export const URL_RULE_SRC = `${URL_GITHUB}/tree/main/packages/${PKG_NAME}/src/rules`;
 /** Get the URL for the rule documentation based on the rule name. @param {string} [ruleName] */
-export const URL_RULE_DOCS = (ruleName = '') => `${URL_HOMEPAGE}/docs/rules/${ruleName}`;
-
+export const URL_RULE_DOCS = (ruleName = '') => `${homepage}/docs/rules/${ruleName}`;
 /** @satisfies {number} */
 export const ZERO_TO_ONE_BASED_OFFSET = 1;

--- a/website/.vitepress/config.js
+++ b/website/.vitepress/config.js
@@ -10,15 +10,7 @@
 import { parse } from 'node:path';
 
 import mark from 'eslint-plugin-mark';
-import {
-  PKG_NAME,
-  PKG_DESCRIPTION,
-  PKG_AUTHOR,
-  URL_HOMEPAGE,
-  URL_GITHUB,
-  URL_NPM,
-  URL_RULE_SRC,
-} from 'eslint-plugin-mark/core/constants';
+import packageJson from 'eslint-plugin-mark/package.json' with { type: 'json' };
 
 import footnote from 'markdown-it-footnote';
 import { defineConfig } from 'vitepress';
@@ -37,6 +29,12 @@ import { createTwoslasher } from 'twoslash-eslint';
 // --------------------------------------------------------------------------------
 
 const GOOGLE_GA_ID = 'G-9KLYX5PTLT';
+const PKG_NAME = packageJson.name;
+const PKG_DESCRIPTION = packageJson.description;
+const PKG_AUTHOR = '루밀LuMir';
+const URL_HOMEPAGE = packageJson.homepage;
+const URL_GITHUB = `https://github.com/lumirlumir/npm-${PKG_NAME}`;
+const URL_RULE_SRC = `${URL_GITHUB}/tree/main/packages/${PKG_NAME}/src/rules`;
 
 // --------------------------------------------------------------------------------
 // Export
@@ -230,7 +228,7 @@ export default defineConfig({
     socialLinks: [
       {
         icon: 'npm',
-        link: `${URL_NPM}/package/eslint-plugin-mark`,
+        link: `https://www.npmjs.com/package/eslint-plugin-mark`,
         ariaLabel: 'npm package link for eslint-plugin-mark',
       },
       {


### PR DESCRIPTION
This pull request refactors how package metadata constants are imported and used across the `eslint-plugin-mark` package and its documentation site. The main goal is to simplify the way metadata is accessed, reduce duplication, and rely directly on `package.json` for metadata in the documentation site. The most important changes are grouped below.

### Package Metadata Refactoring

* Removed the `./core/constants` export from the `exports` and `typesVersions` fields in `package.json`, making the constants module internal and not part of the public API. [[1]](diffhunk://#diff-9b9400561d26b4f60200e53b8fbb54b0ef18955f8348a54f396c6ac386667a0dL11-L14) [[2]](diffhunk://#diff-9b9400561d26b4f60200e53b8fbb54b0ef18955f8348a54f396c6ac386667a0dL24-L26)
* In `src/core/constants.js`, removed several metadata exports (`PKG_DESCRIPTION`, `PKG_AUTHOR`, `URL_HOMEPAGE`, `URL_GITHUB`, `URL_NPM`, `URL_RULE_SRC`) and now only export essential values directly from `package.json`. The rule docs URL generator now uses `homepage` from `package.json`.

### Documentation Site Update

* In `website/.vitepress/config.js`, replaced imports of metadata constants from `eslint-plugin-mark/core/constants` with direct import of `package.json` and reconstructed needed constants locally. [[1]](diffhunk://#diff-44d6965b3c2f9329fe9aacf68bd5c4f638b1ff0d4b1b08649486193c906d68d1L13-R13) [[2]](diffhunk://#diff-44d6965b3c2f9329fe9aacf68bd5c4f638b1ff0d4b1b08649486193c906d68d1R32-R37)
* Updated the npm social link to use a hardcoded URL instead of the removed constant.