### PR TITLE
fix(eslint-plugin-mark): update some rules to use `continue` statement

### DIFF
--- a/packages/eslint-plugin-mark/src/rules/no-control-character.js
+++ b/packages/eslint-plugin-mark/src/rules/no-control-character.js
@@ -98,7 +98,7 @@ export default {
           const startOffset = match.index;
           const endOffset = startOffset + controlCharacter.length;
 
-          if (skipRanges.includes(startOffset)) return;
+          if (skipRanges.includes(startOffset)) continue;
 
           context.report({
             loc: {

--- a/packages/eslint-plugin-mark/src/rules/no-control-character.test.js
+++ b/packages/eslint-plugin-mark/src/rules/no-control-character.test.js
@@ -711,6 +711,22 @@ console.log(\u0003'Hello World');
         },
       ],
     },
+    {
+      name: 'Control character in inline code',
+      code: '`\u0000`\u0000',
+      errors: [
+        {
+          messageId: 'noControlCharacter',
+          line: 1,
+          column: 4,
+          endLine: 1,
+          endColumn: 5,
+          data: {
+            controlCharacter: 'U+0000',
+          },
+        },
+      ],
+    },
 
     // Options
     {

--- a/packages/eslint-plugin-mark/src/rules/no-git-conflict-marker.js
+++ b/packages/eslint-plugin-mark/src/rules/no-git-conflict-marker.js
@@ -90,7 +90,7 @@ export default {
           const startOffset = match.index;
           const endOffset = startOffset + gitConflictMarker.length;
 
-          if (skipRanges.includes(startOffset)) return;
+          if (skipRanges.includes(startOffset)) continue;
 
           context.report({
             loc: {

--- a/packages/eslint-plugin-mark/src/rules/no-git-conflict-marker.test.js
+++ b/packages/eslint-plugin-mark/src/rules/no-git-conflict-marker.test.js
@@ -249,6 +249,22 @@ ruleTester(getFileName(import.meta.url), rule, {
         },
       ],
     },
+    {
+      name: 'Git conflict marker in code',
+      code: '```txt\n>>>>>>>\n```\n>>>>>>>',
+      errors: [
+        {
+          messageId: 'noGitConflictMarker',
+          line: 4,
+          column: 1,
+          endLine: 4,
+          endColumn: 8,
+          data: {
+            gitConflictMarker: '>>>>>>>',
+          },
+        },
+      ],
+    },
 
     // Options
     {

--- a/packages/eslint-plugin-mark/src/rules/no-irregular-whitespace.js
+++ b/packages/eslint-plugin-mark/src/rules/no-irregular-whitespace.js
@@ -99,7 +99,7 @@ export default {
           const startOffset = match.index;
           const endOffset = startOffset + irregularWhitespace.length;
 
-          if (skipRanges.includes(startOffset)) return;
+          if (skipRanges.includes(startOffset)) continue;
 
           context.report({
             loc: {

--- a/packages/eslint-plugin-mark/src/rules/no-irregular-whitespace.test.js
+++ b/packages/eslint-plugin-mark/src/rules/no-irregular-whitespace.test.js
@@ -297,6 +297,22 @@ console.log(\u200b'Hello World');
         },
       ],
     },
+    {
+      name: 'Irregular whitespace in inline code',
+      code: '`\v`\v',
+      errors: [
+        {
+          messageId: 'noIrregularWhitespace',
+          line: 1,
+          column: 4,
+          endLine: 1,
+          endColumn: 5,
+          data: {
+            irregularWhitespace: 'U+000B',
+          },
+        },
+      ],
+    },
 
     // Options
     {


### PR DESCRIPTION
This pull request refines the logic in several ESLint plugin rules and expands their test coverage. The main improvements are the replacement of `return` with `continue` in rule implementations to ensure all matches are processed, and the addition of new test cases to verify detection of problematic characters in inline code and code blocks.

**Rule implementation improvements:**

* Updated the main loop in `no-control-character.js`, `no-git-conflict-marker.js`, and `no-irregular-whitespace.js` to use `continue` instead of `return` when skipping ranges, ensuring all relevant matches are checked and reported. [[1]](diffhunk://#diff-600727e2b3406c181577eece54fb41d6f0ccdf77aabd23790a8d24ec4d38a6c1L101-R101) [[2]](diffhunk://#diff-0c416a0952e8ab77028980d67777d471b05d420ea265b3de2a7c491b9d882dc0L93-R93) [[3]](diffhunk://#diff-288cbdc16eba35be8df40a43f30e54607b19430012d8a876ad8be8d067af5d89L102-R102)

**Test coverage enhancements:**

* Added a test case to `no-control-character.test.js` to verify detection of control characters in inline code.
* Added a test case to `no-git-conflict-marker.test.js` to check for git conflict markers in code blocks.
* Added a test case to `no-irregular-whitespace.test.js` to ensure irregular whitespace is detected in inline code.