### PR TITLE
chore(*): remove unused `markdown-it-footnote` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8011,13 +8011,6 @@
         "markdown-it": "bin/markdown-it.mjs"
       }
     },
-    "node_modules/markdown-it-footnote": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/markdown-it-footnote/-/markdown-it-footnote-4.0.0.tgz",
-      "integrity": "sha512-WYJ7urf+khJYl3DqofQpYfEYkZKbmXmwxQV8c8mO/hGIhgZ1wOe7R4HLFNwqx7TjILbnC98fuyeSsin19JdFcQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/markdown-table": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-2.0.0.tgz",
@@ -14076,7 +14069,6 @@
         "@shikijs/transformers": "^3.14.0",
         "@shikijs/vitepress-twoslash": "^3.14.0",
         "eslint-plugin-mark": "^0.1.0-canary.8",
-        "markdown-it-footnote": "^4.0.0",
         "twoslash-eslint": "^0.3.4",
         "vitepress": "^2.0.0-alpha.12",
         "vitepress-plugin-group-icons": "^1.6.4"

--- a/website/.vitepress/config.js
+++ b/website/.vitepress/config.js
@@ -12,7 +12,6 @@ import { parse } from 'node:path';
 import mark from 'eslint-plugin-mark';
 import packageJson from 'eslint-plugin-mark/package.json' with { type: 'json' };
 
-import footnote from 'markdown-it-footnote';
 import { defineConfig } from 'vitepress';
 import { groupIconMdPlugin, groupIconVitePlugin } from 'vitepress-plugin-group-icons';
 import { codecovVitePlugin } from '@codecov/vite-plugin';
@@ -255,7 +254,6 @@ export default defineConfig({
 
   markdown: {
     config(md) {
-      md.use(footnote);
       md.use(groupIconMdPlugin);
     },
 

--- a/website/package.json
+++ b/website/package.json
@@ -12,7 +12,6 @@
     "@shikijs/transformers": "^3.14.0",
     "@shikijs/vitepress-twoslash": "^3.14.0",
     "eslint-plugin-mark": "^0.1.0-canary.8",
-    "markdown-it-footnote": "^4.0.0",
     "twoslash-eslint": "^0.3.4",
     "vitepress": "^2.0.0-alpha.12",
     "vitepress-plugin-group-icons": "^1.6.4"


### PR DESCRIPTION
This pull request includes minor dependency updates and removes unused packages from the project. The most notable changes are the upgrade of the `eslint` dependency and the removal of the `markdown-it-footnote` package from the website configuration and dependencies.

**Dependency updates:**

* Upgraded `eslint` to version `9.39.0` in both the root `package.json` and the `packages/eslint-plugin-mark/package.json` files. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L42-R42) [[2]](diffhunk://#diff-9b9400561d26b4f60200e53b8fbb54b0ef18955f8348a54f396c6ac386667a0dL70-R70)

**Cleanup of unused packages:**

* Removed the `markdown-it-footnote` dependency from `website/package.json`.
* Removed the import of `footnote` and its usage from `website/.vitepress/config.js`, cleaning up unused markdown plugins. [[1]](diffhunk://#diff-44d6965b3c2f9329fe9aacf68bd5c4f638b1ff0d4b1b08649486193c906d68d1L15) [[2]](diffhunk://#diff-44d6965b3c2f9329fe9aacf68bd5c4f638b1ff0d4b1b08649486193c906d68d1L258)