### PR TITLE
test(eslint-plugin-mark): cleanup rule tests

### DIFF
--- a/packages/eslint-plugin-mark/src/rules/allow-heading.test.js
+++ b/packages/eslint-plugin-mark/src/rules/allow-heading.test.js
@@ -11,13 +11,6 @@ import { getFileName, ruleTester } from '../core/tests/index.js';
 import rule from './allow-heading.js';
 
 // --------------------------------------------------------------------------------
-// Helpers
-// --------------------------------------------------------------------------------
-
-const allowHeading = 'allowHeading';
-const allowHeadingDepth = 'allowHeadingDepth';
-
-// --------------------------------------------------------------------------------
 // Test
 // --------------------------------------------------------------------------------
 
@@ -113,7 +106,7 @@ ruleTester(getFileName(import.meta.url), rule, {
       ],
       errors: [
         {
-          messageId: allowHeading,
+          messageId: 'allowHeading',
           line: 1,
           column: 1,
           endLine: 1,
@@ -132,7 +125,7 @@ ruleTester(getFileName(import.meta.url), rule, {
       ],
       errors: [
         {
-          messageId: allowHeading,
+          messageId: 'allowHeading',
           line: 1,
           column: 1,
           endLine: 1,
@@ -151,7 +144,7 @@ ruleTester(getFileName(import.meta.url), rule, {
       ],
       errors: [
         {
-          messageId: allowHeading,
+          messageId: 'allowHeading',
           line: 1,
           column: 1,
           endLine: 1,
@@ -170,7 +163,7 @@ ruleTester(getFileName(import.meta.url), rule, {
       ],
       errors: [
         {
-          messageId: allowHeading,
+          messageId: 'allowHeading',
           line: 1,
           column: 1,
           endLine: 1,
@@ -189,7 +182,7 @@ ruleTester(getFileName(import.meta.url), rule, {
       ],
       errors: [
         {
-          messageId: allowHeading,
+          messageId: 'allowHeading',
           line: 1,
           column: 1,
           endLine: 1,
@@ -208,7 +201,7 @@ ruleTester(getFileName(import.meta.url), rule, {
       ],
       errors: [
         {
-          messageId: allowHeading,
+          messageId: 'allowHeading',
           line: 1,
           column: 1,
           endLine: 1,
@@ -229,7 +222,7 @@ ruleTester(getFileName(import.meta.url), rule, {
       ],
       errors: [
         {
-          messageId: allowHeadingDepth,
+          messageId: 'allowHeadingDepth',
           line: 1,
           column: 1,
           endLine: 1,
@@ -237,7 +230,7 @@ ruleTester(getFileName(import.meta.url), rule, {
           data: { depth: 1 },
         },
         {
-          messageId: allowHeadingDepth,
+          messageId: 'allowHeadingDepth',
           line: 2,
           column: 1,
           endLine: 2,
@@ -256,7 +249,7 @@ ruleTester(getFileName(import.meta.url), rule, {
       ],
       errors: [
         {
-          messageId: allowHeadingDepth,
+          messageId: 'allowHeadingDepth',
           line: 1,
           column: 1,
           endLine: 1,
@@ -264,7 +257,7 @@ ruleTester(getFileName(import.meta.url), rule, {
           data: { depth: 2 },
         },
         {
-          messageId: allowHeadingDepth,
+          messageId: 'allowHeadingDepth',
           line: 2,
           column: 1,
           endLine: 2,
@@ -283,7 +276,7 @@ ruleTester(getFileName(import.meta.url), rule, {
       ],
       errors: [
         {
-          messageId: allowHeadingDepth,
+          messageId: 'allowHeadingDepth',
           line: 1,
           column: 1,
           endLine: 1,
@@ -291,7 +284,7 @@ ruleTester(getFileName(import.meta.url), rule, {
           data: { depth: 3 },
         },
         {
-          messageId: allowHeadingDepth,
+          messageId: 'allowHeadingDepth',
           line: 2,
           column: 1,
           endLine: 2,
@@ -310,7 +303,7 @@ ruleTester(getFileName(import.meta.url), rule, {
       ],
       errors: [
         {
-          messageId: allowHeadingDepth,
+          messageId: 'allowHeadingDepth',
           line: 1,
           column: 1,
           endLine: 1,
@@ -318,7 +311,7 @@ ruleTester(getFileName(import.meta.url), rule, {
           data: { depth: 4 },
         },
         {
-          messageId: allowHeadingDepth,
+          messageId: 'allowHeadingDepth',
           line: 2,
           column: 1,
           endLine: 2,
@@ -337,7 +330,7 @@ ruleTester(getFileName(import.meta.url), rule, {
       ],
       errors: [
         {
-          messageId: allowHeadingDepth,
+          messageId: 'allowHeadingDepth',
           line: 1,
           column: 1,
           endLine: 1,
@@ -345,7 +338,7 @@ ruleTester(getFileName(import.meta.url), rule, {
           data: { depth: 5 },
         },
         {
-          messageId: allowHeadingDepth,
+          messageId: 'allowHeadingDepth',
           line: 2,
           column: 1,
           endLine: 2,
@@ -364,7 +357,7 @@ ruleTester(getFileName(import.meta.url), rule, {
       ],
       errors: [
         {
-          messageId: allowHeadingDepth,
+          messageId: 'allowHeadingDepth',
           line: 1,
           column: 1,
           endLine: 1,
@@ -372,7 +365,7 @@ ruleTester(getFileName(import.meta.url), rule, {
           data: { depth: 6 },
         },
         {
-          messageId: allowHeadingDepth,
+          messageId: 'allowHeadingDepth',
           line: 2,
           column: 1,
           endLine: 2,

--- a/packages/eslint-plugin-mark/src/rules/code-lang-shorthand.test.js
+++ b/packages/eslint-plugin-mark/src/rules/code-lang-shorthand.test.js
@@ -11,12 +11,6 @@ import { getFileName, ruleTester } from '../core/tests/index.js';
 import rule from './code-lang-shorthand.js';
 
 // --------------------------------------------------------------------------------
-// Helpers
-// --------------------------------------------------------------------------------
-
-const codeLangShorthand = 'codeLangShorthand';
-
-// --------------------------------------------------------------------------------
 // Test
 // --------------------------------------------------------------------------------
 
@@ -77,7 +71,7 @@ const foo = 'bar';
 \`\`\``,
       errors: [
         {
-          messageId: codeLangShorthand,
+          messageId: 'codeLangShorthand',
           line: 1,
           column: 4,
           endLine: 1,
@@ -95,7 +89,7 @@ echo "Hello, World!"
 \`\`\``,
       errors: [
         {
-          messageId: codeLangShorthand,
+          messageId: 'codeLangShorthand',
           line: 1,
           column: 4,
           endLine: 1,
@@ -115,7 +109,7 @@ const foo = 'bar';
 \`\`\``,
       errors: [
         {
-          messageId: codeLangShorthand,
+          messageId: 'codeLangShorthand',
           line: 1,
           column: 4,
           endLine: 1,
@@ -133,7 +127,7 @@ Hello, World!
 \`\`\``,
       errors: [
         {
-          messageId: codeLangShorthand,
+          messageId: 'codeLangShorthand',
           line: 1,
           column: 4,
           endLine: 1,
@@ -153,7 +147,7 @@ const foo = 'bar';
 \`\`\`\``,
       errors: [
         {
-          messageId: codeLangShorthand,
+          messageId: 'codeLangShorthand',
           line: 1,
           column: 5,
           endLine: 1,
@@ -171,7 +165,7 @@ const foo = 'bar';
 ~~~`,
       errors: [
         {
-          messageId: codeLangShorthand,
+          messageId: 'codeLangShorthand',
           line: 1,
           column: 4,
           endLine: 1,
@@ -191,7 +185,7 @@ const foo = 'bar';
 \`\`\``,
       errors: [
         {
-          messageId: codeLangShorthand,
+          messageId: 'codeLangShorthand',
           line: 1,
           column: 4,
           endLine: 1,
@@ -216,7 +210,7 @@ const foo = 'bar';
 \`\`\``,
       errors: [
         {
-          messageId: codeLangShorthand,
+          messageId: 'codeLangShorthand',
           line: 1,
           column: 4,
           endLine: 1,

--- a/packages/eslint-plugin-mark/src/rules/en-capitalization.test.js
+++ b/packages/eslint-plugin-mark/src/rules/en-capitalization.test.js
@@ -11,12 +11,6 @@ import { getFileName, ruleTester } from '../core/tests/index.js';
 import rule from './en-capitalization.js';
 
 // --------------------------------------------------------------------------------
-// Helpers
-// --------------------------------------------------------------------------------
-
-const enCapitalization = 'enCapitalization';
-
-// --------------------------------------------------------------------------------
 // Test
 // --------------------------------------------------------------------------------
 
@@ -138,7 +132,7 @@ ruleTester(getFileName(import.meta.url), rule, {
       output: 'Hello world!',
       errors: [
         {
-          messageId: enCapitalization,
+          messageId: 'enCapitalization',
           line: 1,
           column: 1,
           endLine: 1,
@@ -152,7 +146,7 @@ ruleTester(getFileName(import.meta.url), rule, {
       output: '*Hello* world!',
       errors: [
         {
-          messageId: enCapitalization,
+          messageId: 'enCapitalization',
           line: 1,
           column: 2,
           endLine: 1,
@@ -166,7 +160,7 @@ ruleTester(getFileName(import.meta.url), rule, {
       output: '**Hello** world!',
       errors: [
         {
-          messageId: enCapitalization,
+          messageId: 'enCapitalization',
           line: 1,
           column: 3,
           endLine: 1,
@@ -180,7 +174,7 @@ ruleTester(getFileName(import.meta.url), rule, {
       output: '***Hello*** world!',
       errors: [
         {
-          messageId: enCapitalization,
+          messageId: 'enCapitalization',
           line: 1,
           column: 4,
           endLine: 1,
@@ -194,7 +188,7 @@ ruleTester(getFileName(import.meta.url), rule, {
       output: '_**Hello**_ world!',
       errors: [
         {
-          messageId: enCapitalization,
+          messageId: 'enCapitalization',
           line: 1,
           column: 4,
           endLine: 1,
@@ -211,7 +205,7 @@ ruleTester(getFileName(import.meta.url), rule, {
       options: [{ skipHeading: false }],
       errors: [
         {
-          messageId: enCapitalization,
+          messageId: 'enCapitalization',
           line: 1,
           column: 3,
           endLine: 1,
@@ -226,7 +220,7 @@ ruleTester(getFileName(import.meta.url), rule, {
       options: [{ skipHeading: false }],
       errors: [
         {
-          messageId: enCapitalization,
+          messageId: 'enCapitalization',
           line: 1,
           column: 4,
           endLine: 1,
@@ -241,7 +235,7 @@ ruleTester(getFileName(import.meta.url), rule, {
       options: [{ skipHeading: false }],
       errors: [
         {
-          messageId: enCapitalization,
+          messageId: 'enCapitalization',
           line: 1,
           column: 5,
           endLine: 1,
@@ -256,7 +250,7 @@ ruleTester(getFileName(import.meta.url), rule, {
       options: [{ skipHeading: false }],
       errors: [
         {
-          messageId: enCapitalization,
+          messageId: 'enCapitalization',
           line: 1,
           column: 6,
           endLine: 1,
@@ -271,7 +265,7 @@ ruleTester(getFileName(import.meta.url), rule, {
       options: [{ skipHeading: false }],
       errors: [
         {
-          messageId: enCapitalization,
+          messageId: 'enCapitalization',
           line: 1,
           column: 6,
           endLine: 1,
@@ -288,7 +282,7 @@ ruleTester(getFileName(import.meta.url), rule, {
       options: [{ skipListItem: false }],
       errors: [
         {
-          messageId: enCapitalization,
+          messageId: 'enCapitalization',
           line: 1,
           column: 3,
           endLine: 1,
@@ -303,7 +297,7 @@ ruleTester(getFileName(import.meta.url), rule, {
       options: [{ skipListItem: false }],
       errors: [
         {
-          messageId: enCapitalization,
+          messageId: 'enCapitalization',
           line: 1,
           column: 4,
           endLine: 1,
@@ -318,7 +312,7 @@ ruleTester(getFileName(import.meta.url), rule, {
       options: [{ skipListItem: false }],
       errors: [
         {
-          messageId: enCapitalization,
+          messageId: 'enCapitalization',
           line: 1,
           column: 5,
           endLine: 1,
@@ -333,7 +327,7 @@ ruleTester(getFileName(import.meta.url), rule, {
       options: [{ skipListItem: false }],
       errors: [
         {
-          messageId: enCapitalization,
+          messageId: 'enCapitalization',
           line: 1,
           column: 6,
           endLine: 1,
@@ -348,7 +342,7 @@ ruleTester(getFileName(import.meta.url), rule, {
       options: [{ skipListItem: false }],
       errors: [
         {
-          messageId: enCapitalization,
+          messageId: 'enCapitalization',
           line: 1,
           column: 6,
           endLine: 1,

--- a/packages/eslint-plugin-mark/src/rules/heading-id.test.js
+++ b/packages/eslint-plugin-mark/src/rules/heading-id.test.js
@@ -11,13 +11,6 @@ import { getFileName, ruleTester } from '../core/tests/index.js';
 import rule from './heading-id.js';
 
 // --------------------------------------------------------------------------------
-// Helpers
-// --------------------------------------------------------------------------------
-
-const headingIdAlways = 'headingIdAlways';
-const headingIdNever = 'headingIdNever';
-
-// --------------------------------------------------------------------------------
 // Test
 // --------------------------------------------------------------------------------
 
@@ -149,7 +142,7 @@ ruleTester(getFileName(import.meta.url), rule, {
       code: '# Heading',
       errors: [
         {
-          messageId: headingIdAlways,
+          messageId: 'headingIdAlways',
           line: 1,
           column: 10,
           endLine: 1,
@@ -162,7 +155,7 @@ ruleTester(getFileName(import.meta.url), rule, {
       code: '## Heading',
       errors: [
         {
-          messageId: headingIdAlways,
+          messageId: 'headingIdAlways',
           line: 1,
           column: 11,
           endLine: 1,
@@ -175,7 +168,7 @@ ruleTester(getFileName(import.meta.url), rule, {
       code: '### Heading',
       errors: [
         {
-          messageId: headingIdAlways,
+          messageId: 'headingIdAlways',
           line: 1,
           column: 12,
           endLine: 1,
@@ -188,7 +181,7 @@ ruleTester(getFileName(import.meta.url), rule, {
       code: '#### Heading',
       errors: [
         {
-          messageId: headingIdAlways,
+          messageId: 'headingIdAlways',
           line: 1,
           column: 13,
           endLine: 1,
@@ -201,7 +194,7 @@ ruleTester(getFileName(import.meta.url), rule, {
       code: '##### Heading',
       errors: [
         {
-          messageId: headingIdAlways,
+          messageId: 'headingIdAlways',
           line: 1,
           column: 14,
           endLine: 1,
@@ -214,7 +207,7 @@ ruleTester(getFileName(import.meta.url), rule, {
       code: '###### Heading',
       errors: [
         {
-          messageId: headingIdAlways,
+          messageId: 'headingIdAlways',
           line: 1,
           column: 15,
           endLine: 1,
@@ -229,7 +222,7 @@ ruleTester(getFileName(import.meta.url), rule, {
       code: '# Heading {#}',
       errors: [
         {
-          messageId: headingIdAlways,
+          messageId: 'headingIdAlways',
           line: 1,
           column: 14,
           endLine: 1,
@@ -242,7 +235,7 @@ ruleTester(getFileName(import.meta.url), rule, {
       code: '# Heading { #id}',
       errors: [
         {
-          messageId: headingIdAlways,
+          messageId: 'headingIdAlways',
           line: 1,
           column: 17,
           endLine: 1,
@@ -258,7 +251,7 @@ ruleTester(getFileName(import.meta.url), rule, {
       output: '# Heading ',
       errors: [
         {
-          messageId: headingIdNever,
+          messageId: 'headingIdNever',
           line: 1,
           column: 11,
           endLine: 1,
@@ -273,7 +266,7 @@ ruleTester(getFileName(import.meta.url), rule, {
       output: '## Heading ',
       errors: [
         {
-          messageId: headingIdNever,
+          messageId: 'headingIdNever',
           line: 1,
           column: 12,
           endLine: 1,
@@ -288,7 +281,7 @@ ruleTester(getFileName(import.meta.url), rule, {
       output: '### Heading ',
       errors: [
         {
-          messageId: headingIdNever,
+          messageId: 'headingIdNever',
           line: 1,
           column: 13,
           endLine: 1,
@@ -303,7 +296,7 @@ ruleTester(getFileName(import.meta.url), rule, {
       output: '#### Heading ',
       errors: [
         {
-          messageId: headingIdNever,
+          messageId: 'headingIdNever',
           line: 1,
           column: 14,
           endLine: 1,
@@ -318,7 +311,7 @@ ruleTester(getFileName(import.meta.url), rule, {
       output: '##### Heading ',
       errors: [
         {
-          messageId: headingIdNever,
+          messageId: 'headingIdNever',
           line: 1,
           column: 15,
           endLine: 1,
@@ -333,7 +326,7 @@ ruleTester(getFileName(import.meta.url), rule, {
       output: '###### Heading ',
       errors: [
         {
-          messageId: headingIdNever,
+          messageId: 'headingIdNever',
           line: 1,
           column: 16,
           endLine: 1,


### PR DESCRIPTION
This pull request updates the test files for several ESLint rules in the `eslint-plugin-mark` package to improve consistency and clarity. The main change is replacing references to local constants for `messageId` with string literals in the error objects, and removing unused helper constant declarations at the top of the test files. This makes the tests easier to read and maintain, and aligns them with common ESLint testing practices.

Test maintenance and consistency:

* Replaced local constant references for `messageId` (such as `allowHeading`, `allowHeadingDepth`, `codeLangShorthand`, and `enCapitalization`) with string literals in all error objects within the test cases in `allow-heading.test.js`, `code-lang-shorthand.test.js`, and `en-capitalization.test.js`. [[1]](diffhunk://#diff-268c69571fa6116df81110da0495b0bd097ab719f9507552bcfb382f974b4eefL116-R109) [[2]](diffhunk://#diff-268c69571fa6116df81110da0495b0bd097ab719f9507552bcfb382f974b4eefL232-R233) [[3]](diffhunk://#diff-d7770fac5294882561271fa1dc732f32415598c7d76b8d3b4fe7550eea71091cL80-R74) [[4]](diffhunk://#diff-2a8a4a53a6c695757e1048bf05bed8892eaab427aab2dd0cb1b1486a372508fbL141-R135)
* Removed unused helper constant declarations for rule message IDs from the top of each test file (`allow-heading.test.js`, `code-lang-shorthand.test.js`, and `en-capitalization.test.js`). [[1]](diffhunk://#diff-268c69571fa6116df81110da0495b0bd097ab719f9507552bcfb382f974b4eefL13-L19) [[2]](diffhunk://#diff-d7770fac5294882561271fa1dc732f32415598c7d76b8d3b4fe7550eea71091cL13-L18) [[3]](diffhunk://#diff-2a8a4a53a6c695757e1048bf05bed8892eaab427aab2dd0cb1b1486a372508fbL13-L18)

These changes help streamline the test files and reduce unnecessary indirection, making the error expectations more explicit and easier to follow.