### PR TITLE
refactor(eslint-plugin-mark): replace `forEach` with `for`-`of` loop

### DIFF
--- a/packages/eslint-plugin-mark/src/rules/require-image-title.js
+++ b/packages/eslint-plugin-mark/src/rules/require-image-title.js
@@ -100,7 +100,7 @@ export default {
         const [nodeStartOffset] = sourceCode.getRange(node);
         const html = sourceCode.getText(node);
 
-        getElementsByTagName(html, 'img').forEach(({ attrs, sourceCodeLocation }) => {
+        for (const { attrs, sourceCodeLocation } of getElementsByTagName(html, 'img')) {
           let hasTitle = false;
 
           for (const { name, value } of attrs) {
@@ -120,7 +120,7 @@ export default {
               ),
             });
           }
-        });
+        }
       },
 
       imageReference(node) {

--- a/packages/eslint-plugin-mark/src/rules/require-link-title.js
+++ b/packages/eslint-plugin-mark/src/rules/require-link-title.js
@@ -105,7 +105,7 @@ export default {
         const [nodeStartOffset] = sourceCode.getRange(node);
         const html = sourceCode.getText(node);
 
-        getElementsByTagName(html, 'a').forEach(({ attrs, sourceCodeLocation }) => {
+        for (const { attrs, sourceCodeLocation } of getElementsByTagName(html, 'a')) {
           let hasTitle = false;
 
           for (const { name, value } of attrs) {
@@ -125,7 +125,7 @@ export default {
               ),
             });
           }
-        });
+        }
       },
 
       linkReference(node) {


### PR DESCRIPTION
This pull request refactors the iteration logic in two ESLint plugin rule files to improve readability and consistency. Specifically, it replaces `.forEach` array method calls with `for...of` loops for processing HTML elements in the rules that check for image and link titles.

Refactoring for iteration style:

* Replaced `.forEach` with `for...of` loops when iterating over `<img>` elements in `require-image-title.js`, improving code clarity and consistency. [[1]](diffhunk://#diff-cacd39005d6120dcb804bc81477343ba6f70fd7f21f43bd3ba1004d9a184f4afL103-R103) [[2]](diffhunk://#diff-cacd39005d6120dcb804bc81477343ba6f70fd7f21f43bd3ba1004d9a184f4afL123-R123)
* Replaced `.forEach` with `for...of` loops when iterating over `<a>` elements in `require-link-title.js`, improving code clarity and consistency. [[1]](diffhunk://#diff-76953cc8f1069ee1412eb47d4af3f253821bc1e61c4114aa7de30966dc7f7931L108-R108) [[2]](diffhunk://#diff-76953cc8f1069ee1412eb47d4af3f253821bc1e61c4114aa7de30966dc7f7931L128-R128)