### PR TITLE
chore(release): bump package versions from `v0.1.0-canary.8` to `v0.1.0-canary.9` (`prerelease`)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "npm-eslint-plugin-mark",
-  "version": "0.1.0-canary.8",
+  "version": "0.1.0-canary.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "npm-eslint-plugin-mark",
-      "version": "0.1.0-canary.8",
+      "version": "0.1.0-canary.9",
       "workspaces": [
         ".",
         "packages/*",
@@ -18,7 +18,7 @@
         "editorconfig-checker": "^6.1.1",
         "eslint": "^9.39.1",
         "eslint-config-bananass": "^0.5.2",
-        "eslint-plugin-mark": "^0.1.0-canary.8",
+        "eslint-plugin-mark": "^0.1.0-canary.9",
         "husky": "^9.1.7",
         "lint-staged": "^16.2.6",
         "markdownlint-cli": "^0.45.0",
@@ -10804,7 +10804,7 @@
       }
     },
     "packages/eslint-plugin-mark": {
-      "version": "0.1.0-canary.8",
+      "version": "0.1.0-canary.9",
       "license": "MIT",
       "dependencies": {
         "@eslint/markdown": "^7.5.1",
@@ -10830,7 +10830,7 @@
         "@codecov/vite-plugin": "^1.9.1",
         "@shikijs/transformers": "^3.15.0",
         "@shikijs/vitepress-twoslash": "^3.15.0",
-        "eslint-plugin-mark": "^0.1.0-canary.8",
+        "eslint-plugin-mark": "^0.1.0-canary.9",
         "twoslash-eslint": "^0.3.4",
         "vitepress": "^2.0.0-alpha.13",
         "vitepress-plugin-group-icons": "^1.6.5"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "npm-eslint-plugin-mark",
-  "version": "0.1.0-canary.8",
+  "version": "0.1.0-canary.9",
   "packageManager": "npm@10.9.2",
   "engines": {
     "node": ">=20.19.4"
@@ -40,7 +40,7 @@
     "editorconfig-checker": "^6.1.1",
     "eslint": "^9.39.1",
     "eslint-config-bananass": "^0.5.2",
-    "eslint-plugin-mark": "^0.1.0-canary.8",
+    "eslint-plugin-mark": "^0.1.0-canary.9",
     "husky": "^9.1.7",
     "lint-staged": "^16.2.6",
     "markdownlint-cli": "^0.45.0",

--- a/packages/eslint-plugin-mark/package.json
+++ b/packages/eslint-plugin-mark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-mark",
-  "version": "0.1.0-canary.8",
+  "version": "0.1.0-canary.9",
   "type": "module",
   "description": "Lint your Markdown with ESLint.🛠️",
   "exports": {

--- a/website/package.json
+++ b/website/package.json
@@ -11,7 +11,7 @@
     "@codecov/vite-plugin": "^1.9.1",
     "@shikijs/transformers": "^3.15.0",
     "@shikijs/vitepress-twoslash": "^3.15.0",
-    "eslint-plugin-mark": "^0.1.0-canary.8",
+    "eslint-plugin-mark": "^0.1.0-canary.9",
     "twoslash-eslint": "^0.3.4",
     "vitepress": "^2.0.0-alpha.13",
     "vitepress-plugin-group-icons": "^1.6.5"


### PR DESCRIPTION
## Release Information: `v0.1.0-canary.9`

New release of `lumirlumir/npm-eslint-plugin-mark` has arrived! :tada:

This PR bumps the package versions from `v0.1.0-canary.8` to `v0.1.0-canary.9` (`prerelease`).

See [Actions](https://github.com/lumirlumir/npm-eslint-plugin-mark/actions/runs/19425340893) for more details.

| Info        | Value                      |
| ----------- | -------------------------- |
| Repository  | `lumirlumir/npm-eslint-plugin-mark` |
| SEMVER      | `prerelease`     |
| Pre ID      | `canary`      |
| Short SHA   | 941c553       |
| Old Version | `v0.1.0-canary.8`  |
| New Version | `v0.1.0-canary.9`  |

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### :boom: BREAKING CHANGES
* fix(eslint-plugin-mark)!: remove `/rules` export by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/358
* fix(eslint-plugin-mark)!: remove `/core/tests` export by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/359
* fix(eslint-plugin-mark)!: rewrite configurations by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/367
* fix(eslint-plugin-mark)!: remove `core/constants` export by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/370
* feat(eslint-plugin-mark)!: rename `image-title` rule to `require-image-title` and add options by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/374
* fix(eslint-plugin-mark)!: remove `no-unused-defnition` rule by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/383
### :sparkles: Features
* feat(eslint-plugin-mark): create `consistent-thematic-break-style` rule by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/347
* feat(eslint-plugin-mark): create `consistent-emphasis-style` rule by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/353
* feat(eslint-plugin-mark): create `consistent-strong-style` rule by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/360
* feat(eslint-plugin-mark): create `consistent-delete-style` by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/361
* feat(eslint-plugin-mark): create `require-link-title` rule by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/375
* feat(eslint-plugin-mark): create `allow-link-url` rule by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/392
### :bug: Bug Fixes
* fix(eslint-plugin-mark): bump @eslint/markdown from 7.4.0 to 7.4.1 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/344
* fix(eslint-plugin-mark): update some rules to use `continue` statement by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/373
* fix(eslint-plugin-mark): use `continue` statement and update docs in `no-irregular-dash` by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/348
* fix(*): add optional `peerDependenciesMeta` for `eslint` by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/396
### :hammer_and_wrench: Builds
* build(*): switch to trusted publish and drop `lerna` by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/330
### :toolbox: Chores
* chore(*): update ESLint config by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/319
* chore(sync-server): add `json`, `jsonc`, and `json5` to `lint-staged` config by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/327
* chore(sync-server): bump `actions/setup-node` by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/343
* chore(eslint-plugin-mark): bump `@eslint/markdown` to `7.5.0` by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/351
* chore(*): remove unused `markdown-it-footnote` dependency by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/376
* chore(eslint-plugin-mark): update `tsconfig` settings to enable strict mode by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/382
* chore(eslint-plugin-mark): remove unnecessary dummy files by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/394
* chore(*): bump dev-dependencies by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/395
* chore(*): replace `textlint` with `eslint-plugin-mark` by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/397
### :memo: Documentation
* docs(website): remove AST section across documentation by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/338
* docs(website): update rule documentation to include type information for options by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/355
* docs(website): update `versioning.md` by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/369
### :recycle: Code Refactoring
* refactor(eslint-plugin-mark): refactor and update docs in `no-emoji` by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/324
* refactor(eslint-plugin-mark): refactor and update docs in `no-curly-quote` by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/325
* refactor(eslint-plugin-mark): refactor and update docs in `no-double-space` by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/323
* refactor(eslint-plugin-mark): refactor and update docs in `no-git-conflict-marker` by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/326
* refactor(eslint-plugin-mark): refactor and update docs in `no-irregular-whitespace` by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/328
* refactor(eslint-plugin-mark): flatten directory structure by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/349
* refactor(eslint-plugin-mark): simplify regex in `no-git-conflict-marker` and add tests by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/352
* refactor(eslint-plugin-mark): remove unneeded `meta.docs` properties and create `stylistic` property by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/357
* refactor(eslint-plugin-mark): refactor and update docs in `no-control-character` by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/356
* refactor(eslint-plugin-mark): replace `forEach` with `for`-`of` loop by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/393
### :test_tube: Tests
* test(eslint-plugin-mark): cleanup rule tests by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/388
### :arrow_up: Dependency Updates
* chore(deps-dev): bump @types/node from 24.6.2 to 24.7.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/321
* chore(deps): bump @eslint/markdown from 7.3.0 to 7.4.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/320
* chore(deps-dev): bump @types/node from 24.7.0 to 24.7.1 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/329
* chore(deps-dev): bump the bananass group across 1 directory with 2 updates by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/332
* chore(deps-dev): bump lint-staged from 16.2.3 to 16.2.4 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/331
* chore(deps): bump emoji-regex from 10.5.0 to 10.6.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/333
* chore(deps-dev): bump vitepress-plugin-group-icons from 1.6.3 to 1.6.4 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/336
* chore(deps-dev): bump @types/node from 24.7.1 to 24.8.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/339
* chore(deps-dev): bump eslint from 9.37.0 to 9.38.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/340
* chore(deps-dev): bump @types/node from 24.8.0 to 24.9.1 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/345
* chore(deps-dev): bump lint-staged from 16.2.4 to 16.2.5 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/350
* chore(deps-dev): bump lint-staged from 16.2.5 to 16.2.6 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/354
* chore(deps-dev): bump @shikijs/vitepress-twoslash from 3.13.0 to 3.14.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/365
* chore(deps-dev): bump @shikijs/transformers from 3.13.0 to 3.14.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/366
* chore(deps-dev): bump editorconfig-checker from 6.1.0 to 6.1.1 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/372
* chore(deps-dev): bump @types/node from 24.9.1 to 24.9.2 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/371
* chore(deps-dev): bump @types/node from 24.9.2 to 24.10.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/379
* chore(deps): bump eslint group by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/380
* chore(deps-dev): bump @shikijs/transformers from 3.14.0 to 3.15.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/385
* chore(deps-dev): bump @shikijs/vitepress-twoslash from 3.14.0 to 3.15.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/384
* chore(deps-dev): bump @types/node from 24.10.0 to 24.10.1 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/389


**Full Changelog**: https://github.com/lumirlumir/npm-eslint-plugin-mark/compare/v0.1.0-canary.8...v0.1.0-canary.9