### PR TITLE
chore(release): bump package versions from `v0.1.0-canary.9` to `v0.1.0-canary.10` (`prerelease`)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "npm-eslint-plugin-mark",
-  "version": "0.1.0-canary.9",
+  "version": "0.1.0-canary.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "npm-eslint-plugin-mark",
-      "version": "0.1.0-canary.9",
+      "version": "0.1.0-canary.10",
       "workspaces": [
         ".",
         "packages/*",
@@ -18,7 +18,7 @@
         "editorconfig-checker": "^6.1.1",
         "eslint": "^9.39.1",
         "eslint-config-bananass": "^0.5.2",
-        "eslint-plugin-mark": "^0.1.0-canary.9",
+        "eslint-plugin-mark": "^0.1.0-canary.10",
         "husky": "^9.1.7",
         "lint-staged": "^16.2.6",
         "markdownlint-cli": "^0.45.0",
@@ -10804,7 +10804,7 @@
       }
     },
     "packages/eslint-plugin-mark": {
-      "version": "0.1.0-canary.9",
+      "version": "0.1.0-canary.10",
       "license": "MIT",
       "dependencies": {
         "@eslint/markdown": "^7.5.1",
@@ -10830,7 +10830,7 @@
         "@codecov/vite-plugin": "^1.9.1",
         "@shikijs/transformers": "^3.15.0",
         "@shikijs/vitepress-twoslash": "^3.15.0",
-        "eslint-plugin-mark": "^0.1.0-canary.9",
+        "eslint-plugin-mark": "^0.1.0-canary.10",
         "twoslash-eslint": "^0.3.4",
         "vitepress": "^2.0.0-alpha.13",
         "vitepress-plugin-group-icons": "^1.6.5"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "npm-eslint-plugin-mark",
-  "version": "0.1.0-canary.9",
+  "version": "0.1.0-canary.10",
   "packageManager": "npm@10.9.2",
   "engines": {
     "node": ">=20.19.4"
@@ -40,7 +40,7 @@
     "editorconfig-checker": "^6.1.1",
     "eslint": "^9.39.1",
     "eslint-config-bananass": "^0.5.2",
-    "eslint-plugin-mark": "^0.1.0-canary.9",
+    "eslint-plugin-mark": "^0.1.0-canary.10",
     "husky": "^9.1.7",
     "lint-staged": "^16.2.6",
     "markdownlint-cli": "^0.45.0",

--- a/packages/eslint-plugin-mark/package.json
+++ b/packages/eslint-plugin-mark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-mark",
-  "version": "0.1.0-canary.9",
+  "version": "0.1.0-canary.10",
   "type": "module",
   "description": "Lint your Markdown with ESLint.🛠️",
   "exports": {

--- a/website/package.json
+++ b/website/package.json
@@ -11,7 +11,7 @@
     "@codecov/vite-plugin": "^1.9.1",
     "@shikijs/transformers": "^3.15.0",
     "@shikijs/vitepress-twoslash": "^3.15.0",
-    "eslint-plugin-mark": "^0.1.0-canary.9",
+    "eslint-plugin-mark": "^0.1.0-canary.10",
     "twoslash-eslint": "^0.3.4",
     "vitepress": "^2.0.0-alpha.13",
     "vitepress-plugin-group-icons": "^1.6.5"


### PR DESCRIPTION
## Release Information: `v0.1.0-canary.10`

New release of `lumirlumir/npm-eslint-plugin-mark` has arrived! :tada:

This PR bumps the package versions from `v0.1.0-canary.9` to `v0.1.0-canary.10` (`prerelease`).

See [Actions](https://github.com/lumirlumir/npm-eslint-plugin-mark/actions/runs/19462934128) for more details.

| Info        | Value                      |
| ----------- | -------------------------- |
| Repository  | `lumirlumir/npm-eslint-plugin-mark` |
| SEMVER      | `prerelease`     |
| Pre ID      | `canary`      |
| Short SHA   | bc13327       |
| Old Version | `v0.1.0-canary.9`  |
| New Version | `v0.1.0-canary.10`  |

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### :sparkles: Features
* feat(eslint-plugin-mark): create `allow-image-url` rule by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/391


**Full Changelog**: https://github.com/lumirlumir/npm-eslint-plugin-mark/compare/v0.1.0-canary.9...v0.1.0-canary.10