### PR TITLE
chore(release): bump package versions from `v0.1.0-canary.10` to `v0.1.0-canary.11` (`prerelease`)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "npm-eslint-plugin-mark",
-  "version": "0.1.0-canary.10",
+  "version": "0.1.0-canary.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "npm-eslint-plugin-mark",
-      "version": "0.1.0-canary.10",
+      "version": "0.1.0-canary.11",
       "workspaces": [
         ".",
         "packages/*",
@@ -18,7 +18,7 @@
         "editorconfig-checker": "^6.1.1",
         "eslint": "^9.39.2",
         "eslint-config-bananass": "^0.5.2",
-        "eslint-plugin-mark": "^0.1.0-canary.10",
+        "eslint-plugin-mark": "^0.1.0-canary.11",
         "husky": "^9.1.7",
         "lint-staged": "^16.2.7",
         "markdownlint-cli": "^0.47.0",
@@ -10345,7 +10345,7 @@
       }
     },
     "packages/eslint-plugin-mark": {
-      "version": "0.1.0-canary.10",
+      "version": "0.1.0-canary.11",
       "license": "MIT",
       "dependencies": {
         "@eslint/markdown": "^7.5.1",
@@ -10373,7 +10373,7 @@
         "@codecov/vite-plugin": "^1.9.1",
         "@shikijs/transformers": "^3.20.0",
         "@shikijs/vitepress-twoslash": "^3.20.0",
-        "eslint-plugin-mark": "^0.1.0-canary.10",
+        "eslint-plugin-mark": "^0.1.0-canary.11",
         "twoslash-eslint": "^0.3.4",
         "vitepress": "^2.0.0-alpha.15",
         "vitepress-plugin-group-icons": "^1.6.5"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "npm-eslint-plugin-mark",
-  "version": "0.1.0-canary.10",
+  "version": "0.1.0-canary.11",
   "packageManager": "npm@10.9.2",
   "engines": {
     "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
@@ -40,7 +40,7 @@
     "editorconfig-checker": "^6.1.1",
     "eslint": "^9.39.2",
     "eslint-config-bananass": "^0.5.2",
-    "eslint-plugin-mark": "^0.1.0-canary.10",
+    "eslint-plugin-mark": "^0.1.0-canary.11",
     "husky": "^9.1.7",
     "lint-staged": "^16.2.7",
     "markdownlint-cli": "^0.47.0",

--- a/packages/eslint-plugin-mark/package.json
+++ b/packages/eslint-plugin-mark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-mark",
-  "version": "0.1.0-canary.10",
+  "version": "0.1.0-canary.11",
   "type": "module",
   "description": "Lint your Markdown with ESLint.🛠️",
   "exports": {

--- a/website/package.json
+++ b/website/package.json
@@ -11,7 +11,7 @@
     "@codecov/vite-plugin": "^1.9.1",
     "@shikijs/transformers": "^3.20.0",
     "@shikijs/vitepress-twoslash": "^3.20.0",
-    "eslint-plugin-mark": "^0.1.0-canary.10",
+    "eslint-plugin-mark": "^0.1.0-canary.11",
     "twoslash-eslint": "^0.3.4",
     "vitepress": "^2.0.0-alpha.15",
     "vitepress-plugin-group-icons": "^1.6.5"


### PR DESCRIPTION
## Release Information: `v0.1.0-canary.11`

New release of `lumirlumir/npm-eslint-plugin-mark` has arrived! :tada:

This PR bumps the package versions from `v0.1.0-canary.10` to `v0.1.0-canary.11` (`prerelease`).

See [Actions](https://github.com/lumirlumir/npm-eslint-plugin-mark/actions/runs/20483522662) for more details.

| Info        | Value                      |
| ----------- | -------------------------- |
| Repository  | `lumirlumir/npm-eslint-plugin-mark` |
| SEMVER      | `prerelease`     |
| Pre ID      | `canary`      |
| Short SHA   | b8a89b5       |
| Old Version | `v0.1.0-canary.10`  |
| New Version | `v0.1.0-canary.11`  |

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### :boom: BREAKING CHANGES
* feat(eslint-plugin-mark)!: require Node.js `^20.19.0 || ^22.13.0 || >=24.0.0` by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/424
* fix(eslint-plugin-mark)!: replace `emoji-regex` with native regex by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/425
### :toolbox: Chores
* chore(sync-server): update `dependabot.yml` and dependencies by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/411
* chore(*): update dependencies by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/415
* chore(sync-server): update dev-dependencies by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/418
### :arrow_up: Dependency Updates
* chore(deps-dev): bump lint-staged from 16.2.6 to 16.2.7 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/402
* chore(deps-dev): bump markdownlint-cli from 0.45.0 to 0.46.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/403
* chore(deps-dev): bump glob from 10.4.5 to 10.5.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/404
* chore(deps): bump actions/checkout from 5 to 6 by @lumirlumir in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/406
* chore(deps-dev): bump @shikijs/vitepress-twoslash from 3.15.0 to 3.17.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/407
* chore(deps-dev): bump markdownlint-cli from 0.46.0 to 0.47.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/417
* chore(deps-dev): bump the shikijs group across 1 directory with 2 updates by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/419
* chore(deps-dev): bump @types/node from 24.10.3 to 24.10.4 in the types group across 1 directory by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-plugin-mark/pull/421


**Full Changelog**: https://github.com/lumirlumir/npm-eslint-plugin-mark/compare/v0.1.0-canary.10...v0.1.0-canary.11