### PR TITLE
docs(website): standardize error message quotes in rule documentation

### DIFF
--- a/website/docs/rules/allow-image-url.md
+++ b/website/docs/rules/allow-image-url.md
@@ -20,7 +20,7 @@ Examples of **incorrect** code for this rule:
 #### With `{ allowUrls: [/example.com/] }` Option
 
 ```md eslint-check
-<!-- eslint mark/allow-image-url: ["error", { allowUrls: [/example.com/] }] -->
+<!-- eslint mark/allow-image-url: ['error', { allowUrls: [/example.com/] }] -->
 
 ![Alt text](https://foo.com/image.png)
 
@@ -38,7 +38,7 @@ Examples of **incorrect** code for this rule:
 #### With `{ disallowUrls: [/example.com/] }` Option
 
 ```md eslint-check
-<!-- eslint mark/allow-image-url: ["error", { disallowUrls: [/example.com/] }] -->
+<!-- eslint mark/allow-image-url: ['error', { disallowUrls: [/example.com/] }] -->
 
 ![Alt text](https://example.com/image.png)
 
@@ -66,7 +66,7 @@ By default, this rule reports nothing. To use this rule, please configure the [`
 :::
 
 ```md
-<!-- eslint mark/allow-image-url: "error" -->
+<!-- eslint mark/allow-image-url: 'error' -->
 
 ![Alt text](https://example.com/image.png)
 
@@ -84,7 +84,7 @@ By default, this rule reports nothing. To use this rule, please configure the [`
 #### With `{ allowUrls: [/example.com/] }` Option
 
 ```md eslint-check
-<!-- eslint mark/allow-image-url: ["error", { allowUrls: [/example.com/] }] -->
+<!-- eslint mark/allow-image-url: ['error', { allowUrls: [/example.com/] }] -->
 
 ![Alt text](https://example.com/image.png)
 
@@ -102,7 +102,7 @@ By default, this rule reports nothing. To use this rule, please configure the [`
 #### With `{ disallowUrls: [/example.com/] }` Option
 
 ```md eslint-check
-<!-- eslint mark/allow-image-url: ["error", { disallowUrls: [/example.com/] }] -->
+<!-- eslint mark/allow-image-url: ['error', { disallowUrls: [/example.com/] }] -->
 
 ![Alt text](https://foo.com/image.png)
 
@@ -120,7 +120,7 @@ By default, this rule reports nothing. To use this rule, please configure the [`
 #### With `{ allowDefinitions: ['reference'], disallowUrls: [/example.com/] }` Option
 
 ```md eslint-check
-<!-- eslint mark/allow-image-url: ["error", { allowDefinitions: ['reference'], disallowUrls: [/example.com/] }] -->
+<!-- eslint mark/allow-image-url: ['error', { allowDefinitions: ['reference'], disallowUrls: [/example.com/] }] -->
 
 ![Alt text][reference]
 
@@ -132,7 +132,7 @@ By default, this rule reports nothing. To use this rule, please configure the [`
 Please note that this rule doesn't report definition-style comments (e.g., `[//]: ...`) by default.
 
 ```md eslint-check
-<!-- eslint mark/allow-image-url: ["error", { disallowUrls: [/example.com/] }] -->
+<!-- eslint mark/allow-image-url: ['error', { disallowUrls: [/example.com/] }] -->
 
 ![Alt text][//]
 

--- a/website/docs/rules/allow-link-url.md
+++ b/website/docs/rules/allow-link-url.md
@@ -20,7 +20,7 @@ Examples of **incorrect** code for this rule:
 #### With `{ allowUrls: [/example.com/] }` Option
 
 ```md eslint-check
-<!-- eslint mark/allow-link-url: ["error", { allowUrls: [/example.com/] }] -->
+<!-- eslint mark/allow-link-url: ['error', { allowUrls: [/example.com/] }] -->
 
 [Text](https://foo.com)
 
@@ -40,7 +40,7 @@ Examples of **incorrect** code for this rule:
 #### With `{ disallowUrls: [/example.com/] }` Option
 
 ```md eslint-check
-<!-- eslint mark/allow-link-url: ["error", { disallowUrls: [/example.com/] }] -->
+<!-- eslint mark/allow-link-url: ['error', { disallowUrls: [/example.com/] }] -->
 
 [Text](https://example.com)
 
@@ -70,7 +70,7 @@ By default, this rule reports nothing. To use this rule, please configure the [`
 :::
 
 ```md
-<!-- eslint mark/allow-link-url: "error" -->
+<!-- eslint mark/allow-link-url: 'error' -->
 
 [Text](https://example.com)
 
@@ -90,7 +90,7 @@ By default, this rule reports nothing. To use this rule, please configure the [`
 #### With `{ allowUrls: [/example.com/] }` Option
 
 ```md eslint-check
-<!-- eslint mark/allow-link-url: ["error", { allowUrls: [/example.com/] }] -->
+<!-- eslint mark/allow-link-url: ['error', { allowUrls: [/example.com/] }] -->
 
 [Text](https://example.com)
 
@@ -110,7 +110,7 @@ By default, this rule reports nothing. To use this rule, please configure the [`
 #### With `{ disallowUrls: [/example.com/] }` Option
 
 ```md eslint-check
-<!-- eslint mark/allow-link-url: ["error", { disallowUrls: [/example.com/] }] -->
+<!-- eslint mark/allow-link-url: ['error', { disallowUrls: [/example.com/] }] -->
 
 [Text](https://foo.com)
 
@@ -130,7 +130,7 @@ By default, this rule reports nothing. To use this rule, please configure the [`
 #### With `{ allowDefinitions: ['reference'], disallowUrls: [/example.com/] }` Option
 
 ```md eslint-check
-<!-- eslint mark/allow-link-url: ["error", { allowDefinitions: ['reference'], disallowUrls: [/example.com/] }] -->
+<!-- eslint mark/allow-link-url: ['error', { allowDefinitions: ['reference'], disallowUrls: [/example.com/] }] -->
 
 [Text][reference]
 
@@ -142,7 +142,7 @@ By default, this rule reports nothing. To use this rule, please configure the [`
 Please note that this rule doesn't report definition-style comments (e.g., `[//]: ...`) by default.
 
 ```md eslint-check
-<!-- eslint mark/allow-link-url: ["error", { disallowUrls: [/example.com/] }] -->
+<!-- eslint mark/allow-link-url: ['error', { disallowUrls: [/example.com/] }] -->
 
 [Text][//]
 

--- a/website/docs/rules/consistent-delete-style.md
+++ b/website/docs/rules/consistent-delete-style.md
@@ -16,7 +16,7 @@ Examples of **incorrect** code for this rule:
 #### Default
 
 ```md eslint-check
-<!-- eslint mark/consistent-delete-style: "error" -->
+<!-- eslint mark/consistent-delete-style: 'error' -->
 
 ~foo~
 ~~bar~~
@@ -28,7 +28,7 @@ _~~foo~~_
 ```
 
 ```md eslint-check
-<!-- eslint mark/consistent-delete-style: "error" -->
+<!-- eslint mark/consistent-delete-style: 'error' -->
 
 ~~foo~~
 ~bar~
@@ -42,7 +42,7 @@ _~~bar~~_
 #### With `{ style: '~' }` Option
 
 ```md eslint-check
-<!-- eslint mark/consistent-delete-style: ["error", { style: '~' }] -->
+<!-- eslint mark/consistent-delete-style: ['error', { style: '~' }] -->
 
 ~~foo~~
 ~~_bar_~~
@@ -52,7 +52,7 @@ _~~baz~~_
 #### With `{ style: '~~' }` Option
 
 ```md eslint-check
-<!-- eslint mark/consistent-delete-style: ["error", { style: '~~' }] -->
+<!-- eslint mark/consistent-delete-style: ['error', { style: '~~' }] -->
 
 ~foo~
 __~bar~__
@@ -66,7 +66,7 @@ Examples of **correct** code for this rule:
 #### Default
 
 ```md eslint-check
-<!-- eslint mark/consistent-delete-style: "error" -->
+<!-- eslint mark/consistent-delete-style: 'error' -->
 
 ~foo~
 ~bar~
@@ -75,7 +75,7 @@ __~baz~__
 ```
 
 ```md eslint-check
-<!-- eslint mark/consistent-delete-style: "error" -->
+<!-- eslint mark/consistent-delete-style: 'error' -->
 
 ~~foo~~
 ~~bar~~
@@ -86,7 +86,7 @@ _~~qux~~_
 #### With `{ style: '~' }` Option
 
 ```md eslint-check
-<!-- eslint mark/consistent-delete-style: ["error", { style: '~' }] -->
+<!-- eslint mark/consistent-delete-style: ['error', { style: '~' }] -->
 
 ~foo~
 ~bar~
@@ -97,7 +97,7 @@ __~baz~__
 #### With `{ style: '~~' }` Option
 
 ```md eslint-check
-<!-- eslint mark/consistent-delete-style: ["error", { style: '~~' }] -->
+<!-- eslint mark/consistent-delete-style: ['error', { style: '~~' }] -->
 
 ~~foo~~
 ~~bar~~

--- a/website/docs/rules/consistent-emphasis-style.md
+++ b/website/docs/rules/consistent-emphasis-style.md
@@ -16,7 +16,7 @@ Examples of **incorrect** code for this rule:
 #### Default
 
 ```md eslint-check
-<!-- eslint mark/consistent-emphasis-style: "error" -->
+<!-- eslint mark/consistent-emphasis-style: 'error' -->
 
 *foo*
 _bar_
@@ -30,7 +30,7 @@ ___foo___
 ```
 
 ```md eslint-check
-<!-- eslint mark/consistent-emphasis-style: "error" -->
+<!-- eslint mark/consistent-emphasis-style: 'error' -->
 
 _foo_
 *bar*
@@ -46,7 +46,7 @@ ___bar___
 #### With `{ style: '*' }` Option
 
 ```md eslint-check
-<!-- eslint mark/consistent-emphasis-style: ["error", { style: '*' }] -->
+<!-- eslint mark/consistent-emphasis-style: ['error', { style: '*' }] -->
 
 _foo_
 **_bar_**
@@ -57,7 +57,7 @@ ___qux___
 #### With `{ style: '_' }` Option
 
 ```md eslint-check
-<!-- eslint mark/consistent-emphasis-style: ["error", { style: '_' }] -->
+<!-- eslint mark/consistent-emphasis-style: ['error', { style: '_' }] -->
 
 *foo*
 __*bar*__
@@ -72,7 +72,7 @@ Examples of **correct** code for this rule:
 #### Default
 
 ```md eslint-check
-<!-- eslint mark/consistent-emphasis-style: "error" -->
+<!-- eslint mark/consistent-emphasis-style: 'error' -->
 
 *foo*
 __*bar*__
@@ -81,7 +81,7 @@ __*bar*__
 ```
 
 ```md eslint-check
-<!-- eslint mark/consistent-emphasis-style: "error" -->
+<!-- eslint mark/consistent-emphasis-style: 'error' -->
 
 _foo_
 **_bar_**
@@ -92,7 +92,7 @@ ___qux___
 #### With `{ style: '*' }` Option
 
 ```md eslint-check
-<!-- eslint mark/consistent-emphasis-style: ["error", { style: '*' }] -->
+<!-- eslint mark/consistent-emphasis-style: ['error', { style: '*' }] -->
 
 *foo*
 __*bar*__
@@ -103,7 +103,7 @@ __*bar*__
 #### With `{ style: '_' }` Option
 
 ```md eslint-check
-<!-- eslint mark/consistent-emphasis-style: ["error", { style: '_' }] -->
+<!-- eslint mark/consistent-emphasis-style: ['error', { style: '_' }] -->
 
 _foo_
 **_bar_**

--- a/website/docs/rules/consistent-strong-style.md
+++ b/website/docs/rules/consistent-strong-style.md
@@ -16,7 +16,7 @@ Examples of **incorrect** code for this rule:
 #### Default
 
 ```md eslint-check
-<!-- eslint mark/consistent-strong-style: "error" -->
+<!-- eslint mark/consistent-strong-style: 'error' -->
 
 **foo**
 __bar__
@@ -30,7 +30,7 @@ ___foo___
 ```
 
 ```md eslint-check
-<!-- eslint mark/consistent-strong-style: "error" -->
+<!-- eslint mark/consistent-strong-style: 'error' -->
 
 __foo__
 **bar**
@@ -46,7 +46,7 @@ ___bar___
 #### With `{ style: '*' }` Option
 
 ```md eslint-check
-<!-- eslint mark/consistent-strong-style: ["error", { style: '*' }] -->
+<!-- eslint mark/consistent-strong-style: ['error', { style: '*' }] -->
 
 __foo__
 __*bar*__
@@ -57,7 +57,7 @@ ___qux___
 #### With `{ style: '_' }` Option
 
 ```md eslint-check
-<!-- eslint mark/consistent-strong-style: ["error", { style: '_' }] -->
+<!-- eslint mark/consistent-strong-style: ['error', { style: '_' }] -->
 
 **foo**
 **_bar_**
@@ -72,7 +72,7 @@ Examples of **correct** code for this rule:
 #### Default
 
 ```md eslint-check
-<!-- eslint mark/consistent-strong-style: "error" -->
+<!-- eslint mark/consistent-strong-style: 'error' -->
 
 **foo**
 **_bar_**
@@ -81,7 +81,7 @@ _**baz**_
 ```
 
 ```md eslint-check
-<!-- eslint mark/consistent-strong-style: "error" -->
+<!-- eslint mark/consistent-strong-style: 'error' -->
 
 __foo__
 __*bar*__
@@ -92,7 +92,7 @@ ___qux___
 #### With `{ style: '*' }` Option
 
 ```md eslint-check
-<!-- eslint mark/consistent-strong-style: ["error", { style: '*' }] -->
+<!-- eslint mark/consistent-strong-style: ['error', { style: '*' }] -->
 
 **foo**
 **_bar_**
@@ -103,7 +103,7 @@ _**baz**_
 #### With `{ style: '_' }` Option
 
 ```md eslint-check
-<!-- eslint mark/consistent-strong-style: ["error", { style: '_' }] -->
+<!-- eslint mark/consistent-strong-style: ['error', { style: '_' }] -->
 
 __foo__
 __*bar*__

--- a/website/docs/rules/consistent-thematic-break-style.md
+++ b/website/docs/rules/consistent-thematic-break-style.md
@@ -16,7 +16,7 @@ Examples of **incorrect** code for this rule:
 #### Default
 
 ```md eslint-check
-<!-- eslint mark/consistent-thematic-break-style: "error" -->
+<!-- eslint mark/consistent-thematic-break-style: 'error' -->
 
 ---
 - - -
@@ -27,7 +27,7 @@ ___
 ```
 
 ```md eslint-check
-<!-- eslint mark/consistent-thematic-break-style: "error" -->
+<!-- eslint mark/consistent-thematic-break-style: 'error' -->
 
 ***
 * * *
@@ -38,7 +38,7 @@ ___
 ```
 
 ```md eslint-check
-<!-- eslint mark/consistent-thematic-break-style: "error" -->
+<!-- eslint mark/consistent-thematic-break-style: 'error' -->
 
 ___
 ---
@@ -51,7 +51,7 @@ ___
 #### With `{ style: '- - -' }` Option
 
 ```md eslint-check
-<!-- eslint mark/consistent-thematic-break-style: ["error", { style: '- - -' }] -->
+<!-- eslint mark/consistent-thematic-break-style: ['error', { style: '- - -' }] -->
 
 ---
 ***
@@ -65,7 +65,7 @@ Examples of **correct** code for this rule:
 #### Default
 
 ```md eslint-check
-<!-- eslint mark/consistent-thematic-break-style: "error" -->
+<!-- eslint mark/consistent-thematic-break-style: 'error' -->
 
 ---
 ---
@@ -73,7 +73,7 @@ Examples of **correct** code for this rule:
 ```
 
 ```md eslint-check
-<!-- eslint mark/consistent-thematic-break-style: "error" -->
+<!-- eslint mark/consistent-thematic-break-style: 'error' -->
 
 ***
 ***
@@ -81,7 +81,7 @@ Examples of **correct** code for this rule:
 ```
 
 ```md eslint-check
-<!-- eslint mark/consistent-thematic-break-style: "error" -->
+<!-- eslint mark/consistent-thematic-break-style: 'error' -->
 
 ___
 ___
@@ -91,7 +91,7 @@ ___
 #### With `{ style: '- - -' }` Option
 
 ```md eslint-check
-<!-- eslint mark/consistent-thematic-break-style: ["error", { style: '- - -' }] -->
+<!-- eslint mark/consistent-thematic-break-style: ['error', { style: '- - -' }] -->
 
 - - -
 - - -

--- a/website/docs/rules/no-control-character.md
+++ b/website/docs/rules/no-control-character.md
@@ -92,7 +92,7 @@ Examples of **incorrect** code for this rule:
 #### Default
 
 ```md eslint-check
-<!-- eslint mark/no-control-character: "error" -->
+<!-- eslint mark/no-control-character: 'error' -->
 
 \u0002 - Start of Text - <STX>  <= Here
 \u0003 - End of Text - <ETX>  <= Here
@@ -132,7 +132,7 @@ Examples of **incorrect** code for this rule:
 #### With `{ skipCode: false }` Option
 
 `````md eslint-check
-<!-- eslint mark/no-control-character: ["error", { skipCode: false }] -->
+<!-- eslint mark/no-control-character: ['error', { skipCode: false }] -->
 
 ```md
 \u0002 - Start of Text - <STX>  <= Here
@@ -156,7 +156,7 @@ Examples of **incorrect** code for this rule:
 #### With `{ skipInlineCode: false }` Option
 
 ```md eslint-check
-<!-- eslint mark/no-control-character: ["error", { skipInlineCode: false }] -->
+<!-- eslint mark/no-control-character: ['error', { skipInlineCode: false }] -->
 
 \u0002 - Start of Text - <STX> `` <= Here
 \u0003 - End of Text - <ETX> `` <= Here
@@ -171,7 +171,7 @@ Examples of **correct** code for this rule:
 <!-- markdownlint-disable no-hard-tabs -->
 
 ```md eslint-check
-<!-- eslint mark/no-control-character: "error" -->
+<!-- eslint mark/no-control-character: 'error' -->
 
 \u0009 - Horizontal Tab (\t) - <TAB> 	 <= Here
 \u0020 - Space - <SP>   <= Here
@@ -182,7 +182,7 @@ Examples of **correct** code for this rule:
 #### With `{ skipCode: true }` Option
 
 `````md eslint-check
-<!-- eslint mark/no-control-character: ["error", { skipCode: true }] -->
+<!-- eslint mark/no-control-character: ['error', { skipCode: true }] -->
 
 ```md
 \u0002 - Start of Text - <STX>  <= Here
@@ -206,7 +206,7 @@ Examples of **correct** code for this rule:
 #### With `{ skipInlineCode: true }` Option
 
 ```md eslint-check
-<!-- eslint mark/no-control-character: ["error", { skipInlineCode: true }] -->
+<!-- eslint mark/no-control-character: ['error', { skipInlineCode: true }] -->
 
 \u0002 - Start of Text - <STX> `` <= Here
 \u0003 - End of Text - <ETX> `` <= Here

--- a/website/docs/rules/no-curly-quote.md
+++ b/website/docs/rules/no-curly-quote.md
@@ -20,7 +20,7 @@ Examples of **incorrect** code for this rule:
 #### Default
 
 ```md eslint-check
-<!-- eslint mark/no-curly-quote: "error" -->
+<!-- eslint mark/no-curly-quote: 'error' -->
 
 “foo bar”
 ‘foo bar’
@@ -30,7 +30,7 @@ Examples of **incorrect** code for this rule:
 #### With `{ checkLeftDoubleQuotationMark: false }` Option
 
 ```md eslint-check
-<!-- eslint mark/no-curly-quote: ["error", { checkLeftDoubleQuotationMark: false }] -->
+<!-- eslint mark/no-curly-quote: ['error', { checkLeftDoubleQuotationMark: false }] -->
 
 “foo bar”
 ‘foo bar’
@@ -44,7 +44,7 @@ Examples of **correct** code for this rule:
 #### Default
 
 ```md eslint-check
-<!-- eslint mark/no-curly-quote: "error" -->
+<!-- eslint mark/no-curly-quote: 'error' -->
 
 "foo bar"
 'foo bar'

--- a/website/docs/rules/no-double-space.md
+++ b/website/docs/rules/no-double-space.md
@@ -20,7 +20,7 @@ Examples of **incorrect** code for this rule:
 #### Default
 
 ```md eslint-check
-<!-- eslint mark/no-double-space: "error" -->
+<!-- eslint mark/no-double-space: 'error' -->
 
 foo  bar  baz
 ```
@@ -28,7 +28,7 @@ foo  bar  baz
 #### With `{ checkMultipleSpace: true }` Option
 
 ```md eslint-check
-<!-- eslint mark/no-double-space: ["error", { checkMultipleSpace: true }] -->
+<!-- eslint mark/no-double-space: ['error', { checkMultipleSpace: true }] -->
 
 foo  bar  baz
 foo   bar   baz
@@ -42,7 +42,7 @@ Examples of **correct** code for this rule:
 #### Default
 
 ```md eslint-check
-<!-- eslint mark/no-double-space: "error" -->
+<!-- eslint mark/no-double-space: 'error' -->
 
 foo bar baz qux
 
@@ -58,7 +58,7 @@ foo bar    <!-- trailing multiple space⁡ -->
 #### With `{ checkMultipleSpace: true }` Option
 
 ```md eslint-check
-<!-- eslint mark/no-double-space: ["error", { checkMultipleSpace: true }] -->
+<!-- eslint mark/no-double-space: ['error', { checkMultipleSpace: true }] -->
 
 foo bar baz qux
 

--- a/website/docs/rules/no-emoji.md
+++ b/website/docs/rules/no-emoji.md
@@ -26,7 +26,7 @@ Platforms like [GitHub](https://github.com) and Markdown plugins such as [`remar
 Examples of **incorrect** code for this rule:
 
 ```md eslint-check
-<!-- eslint mark/no-emoji: "error" -->
+<!-- eslint mark/no-emoji: 'error' -->
 
 Smiley 😃
 Unicorn 🦄
@@ -38,7 +38,7 @@ Unicorn 🦄
 Examples of **correct** code for this rule:
 
 ```md eslint-check
-<!-- eslint mark/no-emoji: "error" -->
+<!-- eslint mark/no-emoji: 'error' -->
 
 Smiley :smiley:
 Unicorn :unicorn:

--- a/website/docs/rules/no-git-conflict-marker.md
+++ b/website/docs/rules/no-git-conflict-marker.md
@@ -28,7 +28,7 @@ Examples of **incorrect** code for this rule:
 #### Default
 
   ```md eslint-check
-  <!-- eslint mark/no-git-conflict-marker: "error" -->
+  <!-- eslint mark/no-git-conflict-marker: 'error' -->
 
   # My Document
 
@@ -44,7 +44,7 @@ Examples of **incorrect** code for this rule:
 #### With `{ skipCode: false }` Option
 
   ````md eslint-check
-  <!-- eslint mark/no-git-conflict-marker: ["error", { skipCode: false }] -->
+  <!-- eslint mark/no-git-conflict-marker: ['error', { skipCode: false }] -->
 
   # My Document
 
@@ -66,7 +66,7 @@ Examples of **correct** code for this rule:
 #### Default
 
   ```md eslint-check
-  <!-- eslint mark/no-git-conflict-marker: "error" -->
+  <!-- eslint mark/no-git-conflict-marker: 'error' -->
 
   # My Document
 
@@ -78,7 +78,7 @@ Examples of **correct** code for this rule:
 #### With `{ skipCode: true }` Option
 
   ````md eslint-check
-  <!-- eslint mark/no-git-conflict-marker: ["error", { skipCode: true }] -->
+  <!-- eslint mark/no-git-conflict-marker: ['error', { skipCode: true }] -->
 
   # My Document
 

--- a/website/docs/rules/no-irregular-dash.md
+++ b/website/docs/rules/no-irregular-dash.md
@@ -38,7 +38,7 @@ Examples of **incorrect** code for this rule:
 #### Default
 
 ```md eslint-check
-<!-- eslint mark/no-irregular-dash: "error" -->
+<!-- eslint mark/no-irregular-dash: 'error' -->
 
 \u2010 - Hyphen - <HYPH> ‐ <= Here
 \u2011 - Non-Breaking Hyphen - <NBHY> ‑ <= Here
@@ -60,7 +60,7 @@ Examples of **incorrect** code for this rule:
 #### With `{ skipCode: false }` Option
 
 `````md eslint-check
-<!-- eslint mark/no-irregular-dash: ["error", { skipCode: false }] -->
+<!-- eslint mark/no-irregular-dash: ['error', { skipCode: false }] -->
 
 ```md
 \u2010 - Hyphen - <HYPH> ‐ <= Here
@@ -84,7 +84,7 @@ Examples of **incorrect** code for this rule:
 #### With `{ skipInlineCode: false }` Option
 
 ```md eslint-check
-<!-- eslint mark/no-irregular-dash: ["error", { skipInlineCode: false }] -->
+<!-- eslint mark/no-irregular-dash: ['error', { skipInlineCode: false }] -->
 
 \u2010 - Hyphen - <HYPH> `‐` <= Here
 \u2011 - Non-Breaking Hyphen - <NBHY> `‑` <= Here
@@ -97,7 +97,7 @@ Examples of **correct** code for this rule:
 #### Default
 
 ```md eslint-check
-<!-- eslint mark/no-irregular-dash: "error" -->
+<!-- eslint mark/no-irregular-dash: 'error' -->
 
 \u002D - Hyphen Minus - <HYPHMNUS> - <= Here
 ```
@@ -105,7 +105,7 @@ Examples of **correct** code for this rule:
 #### With `{ skipCode: true }` Option
 
 `````md eslint-check
-<!-- eslint mark/no-irregular-dash: ["error", { skipCode: true }] -->
+<!-- eslint mark/no-irregular-dash: ['error', { skipCode: true }] -->
 
 ```md
 \u2010 - Hyphen - <HYPH> ‐ <= Here
@@ -129,7 +129,7 @@ Examples of **correct** code for this rule:
 #### With `{ skipInlineCode: true }` Option
 
 ```md eslint-check
-<!-- eslint mark/no-irregular-dash: ["error", { skipInlineCode: true }] -->
+<!-- eslint mark/no-irregular-dash: ['error', { skipInlineCode: true }] -->
 
 \u2010 - Hyphen - <HYPH> `‐` <= Here
 \u2011 - Non-Breaking Hyphen - <NBHY> `‑` <= Here

--- a/website/docs/rules/no-irregular-whitespace.md
+++ b/website/docs/rules/no-irregular-whitespace.md
@@ -57,7 +57,7 @@ Examples of **incorrect** code for this rule:
 #### Default
 
 ```md eslint-check
-<!-- eslint mark/no-irregular-whitespace: "error" -->
+<!-- eslint mark/no-irregular-whitespace: 'error' -->
 
 \u000B - Line Tabulation (\v) - <VT>  <= Here
 \u0085 - Next Line - <NEL>  <= Here
@@ -83,7 +83,7 @@ Examples of **incorrect** code for this rule:
 #### With `{ skipCode: false }` Option
 
 `````md eslint-check
-<!-- eslint mark/no-irregular-whitespace: ["error", { skipCode: false }] -->
+<!-- eslint mark/no-irregular-whitespace: ['error', { skipCode: false }] -->
 
 ```md
 \u000B - Line Tabulation (\v) - <VT>  <= Here
@@ -107,7 +107,7 @@ Examples of **incorrect** code for this rule:
 #### With `{ skipInlineCode: false }` Option
 
 ```md eslint-check
-<!-- eslint mark/no-irregular-whitespace: ["error", { skipInlineCode: false }] -->
+<!-- eslint mark/no-irregular-whitespace: ['error', { skipInlineCode: false }] -->
 
 \u000B - Line Tabulation (\v) - <VT> `` <= Here
 \u0085 - Next Line - <NEL> `` <= Here
@@ -122,7 +122,7 @@ Examples of **correct** code for this rule:
 <!-- markdownlint-disable no-hard-tabs -->
 
 ```md eslint-check
-<!-- eslint mark/no-irregular-whitespace: "error" -->
+<!-- eslint mark/no-irregular-whitespace: 'error' -->
 
 \u0009 - Horizontal Tab (\t) - <TAB> 	 <= Here
 \u0020 - Space - <SP>   <= Here
@@ -133,7 +133,7 @@ Examples of **correct** code for this rule:
 #### With `{ skipCode: true }` Option
 
 `````md eslint-check
-<!-- eslint mark/no-irregular-whitespace: ["error", { skipCode: true }] -->
+<!-- eslint mark/no-irregular-whitespace: ['error', { skipCode: true }] -->
 
 ```md
 \u000B - Line Tabulation (\v) - <VT>  <= Here
@@ -157,7 +157,7 @@ Examples of **correct** code for this rule:
 #### With `{ skipInlineCode: true }` Option
 
 ```md eslint-check
-<!-- eslint mark/no-irregular-whitespace: ["error", { skipInlineCode: true }] -->
+<!-- eslint mark/no-irregular-whitespace: ['error', { skipInlineCode: true }] -->
 
 \u000B - Line Tabulation (\v) - <VT> `` <= Here
 \u0085 - Next Line - <NEL> `` <= Here

--- a/website/docs/rules/require-image-title.md
+++ b/website/docs/rules/require-image-title.md
@@ -20,7 +20,7 @@ Examples of **incorrect** code for this rule:
 #### Default
 
 ```md eslint-check
-<!-- eslint mark/require-image-title: "error" -->
+<!-- eslint mark/require-image-title: 'error' -->
 
 ![Alt text](https://example.com/image.png)
 
@@ -42,7 +42,7 @@ Examples of **correct** code for this rule:
 #### Default
 
 ```md
-<!-- eslint mark/require-image-title: "error" -->
+<!-- eslint mark/require-image-title: 'error' -->
 
 ![Alt text](https://example.com/image.png "Image title")
 
@@ -62,7 +62,7 @@ Examples of **correct** code for this rule:
 Please note that this rule doesn't report definition-style comments (e.g., `[//]: ...`) by default.
 
 ```md eslint-check
-<!-- eslint mark/require-image-title: "error" -->
+<!-- eslint mark/require-image-title: 'error' -->
 
 ![Alt text][//]
 
@@ -74,7 +74,7 @@ Please note that this rule doesn't report definition-style comments (e.g., `[//]
 #### With `{ allowDefinitions: ['reference'] }` Option
 
 ```md eslint-check
-<!-- eslint mark/require-image-title: ["error", { allowDefinitions: ['reference'] }] -->
+<!-- eslint mark/require-image-title: ['error', { allowDefinitions: ['reference'] }] -->
 
 ![Alt text][reference]
 

--- a/website/docs/rules/require-link-title.md
+++ b/website/docs/rules/require-link-title.md
@@ -20,7 +20,7 @@ Examples of **incorrect** code for this rule:
 #### Default
 
 ```md eslint-check
-<!-- eslint mark/require-link-title: "error" -->
+<!-- eslint mark/require-link-title: 'error' -->
 
 [Text](https://example.com)
 
@@ -42,7 +42,7 @@ Examples of **correct** code for this rule:
 #### Default
 
 ```md
-<!-- eslint mark/require-link-title: "error" -->
+<!-- eslint mark/require-link-title: 'error' -->
 
 [Text](https://example.com "Link title")
 
@@ -62,7 +62,7 @@ Examples of **correct** code for this rule:
 Please note that this rule doesn't report definition-style comments (e.g., `[//]: ...`) by default.
 
 ```md eslint-check
-<!-- eslint mark/require-link-title: "error" -->
+<!-- eslint mark/require-link-title: 'error' -->
 
 [Text][//]
 
@@ -74,7 +74,7 @@ Please note that this rule doesn't report definition-style comments (e.g., `[//]
 #### With `{ allowDefinitions: ['reference'] }` Option
 
 ```md eslint-check
-<!-- eslint mark/require-link-title: ["error", { allowDefinitions: ['reference'] }] -->
+<!-- eslint mark/require-link-title: ['error', { allowDefinitions: ['reference'] }] -->
 
 [Text][reference]
 


### PR DESCRIPTION
This pull request updates documentation examples for several Markdown linting rules to use single quotes instead of double quotes in ESLint configuration comments. This change ensures consistency and matches the preferred quoting style across all rule documentation.

The most important changes are:

**Quoting style consistency in documentation examples:**

* Changed ESLint configuration comments from double quotes (`"error"`, `["error", ...]`) to single quotes (`'error'`, `['error', ...]`) in the following rule docs:
  - `allow-image-url.md` [[1]](diffhunk://#diff-59125496760ab741db8fcf56c89cbf6875992f3570125a2788692cdcfc6846dbL23-R23) [[2]](diffhunk://#diff-59125496760ab741db8fcf56c89cbf6875992f3570125a2788692cdcfc6846dbL41-R41) [[3]](diffhunk://#diff-59125496760ab741db8fcf56c89cbf6875992f3570125a2788692cdcfc6846dbL69-R69) [[4]](diffhunk://#diff-59125496760ab741db8fcf56c89cbf6875992f3570125a2788692cdcfc6846dbL87-R87) [[5]](diffhunk://#diff-59125496760ab741db8fcf56c89cbf6875992f3570125a2788692cdcfc6846dbL105-R105) [[6]](diffhunk://#diff-59125496760ab741db8fcf56c89cbf6875992f3570125a2788692cdcfc6846dbL123-R123) [[7]](diffhunk://#diff-59125496760ab741db8fcf56c89cbf6875992f3570125a2788692cdcfc6846dbL135-R135)
  - `allow-link-url.md` [[1]](diffhunk://#diff-949cb3cd2f329bb907f06c3f63abe58c3f06edd3a972924c349baff4ee71b71eL23-R23) [[2]](diffhunk://#diff-949cb3cd2f329bb907f06c3f63abe58c3f06edd3a972924c349baff4ee71b71eL43-R43) [[3]](diffhunk://#diff-949cb3cd2f329bb907f06c3f63abe58c3f06edd3a972924c349baff4ee71b71eL73-R73) [[4]](diffhunk://#diff-949cb3cd2f329bb907f06c3f63abe58c3f06edd3a972924c349baff4ee71b71eL93-R93) [[5]](diffhunk://#diff-949cb3cd2f329bb907f06c3f63abe58c3f06edd3a972924c349baff4ee71b71eL113-R113) [[6]](diffhunk://#diff-949cb3cd2f329bb907f06c3f63abe58c3f06edd3a972924c349baff4ee71b71eL133-R133) [[7]](diffhunk://#diff-949cb3cd2f329bb907f06c3f63abe58c3f06edd3a972924c349baff4ee71b71eL145-R145)
  - `consistent-delete-style.md` [[1]](diffhunk://#diff-79fc0b7b040e156b919d9ff823b87006ee2798e25ff1384e05770739ea4bcadaL19-R19) [[2]](diffhunk://#diff-79fc0b7b040e156b919d9ff823b87006ee2798e25ff1384e05770739ea4bcadaL31-R31) [[3]](diffhunk://#diff-79fc0b7b040e156b919d9ff823b87006ee2798e25ff1384e05770739ea4bcadaL45-R45) [[4]](diffhunk://#diff-79fc0b7b040e156b919d9ff823b87006ee2798e25ff1384e05770739ea4bcadaL55-R55) [[5]](diffhunk://#diff-79fc0b7b040e156b919d9ff823b87006ee2798e25ff1384e05770739ea4bcadaL69-R69) [[6]](diffhunk://#diff-79fc0b7b040e156b919d9ff823b87006ee2798e25ff1384e05770739ea4bcadaL78-R78) [[7]](diffhunk://#diff-79fc0b7b040e156b919d9ff823b87006ee2798e25ff1384e05770739ea4bcadaL89-R89) [[8]](diffhunk://#diff-79fc0b7b040e156b919d9ff823b87006ee2798e25ff1384e05770739ea4bcadaL100-R100)
  - `consistent-emphasis-style.md` [[1]](diffhunk://#diff-831ff69f21b3a3702b066efd03c316febd2b35c3391754c5e72dc1068e9321e7L19-R19) [[2]](diffhunk://#diff-831ff69f21b3a3702b066efd03c316febd2b35c3391754c5e72dc1068e9321e7L33-R33) [[3]](diffhunk://#diff-831ff69f21b3a3702b066efd03c316febd2b35c3391754c5e72dc1068e9321e7L49-R49) [[4]](diffhunk://#diff-831ff69f21b3a3702b066efd03c316febd2b35c3391754c5e72dc1068e9321e7L60-R60) [[5]](diffhunk://#diff-831ff69f21b3a3702b066efd03c316febd2b35c3391754c5e72dc1068e9321e7L75-R75) [[6]](diffhunk://#diff-831ff69f21b3a3702b066efd03c316febd2b35c3391754c5e72dc1068e9321e7L84-R84) [[7]](diffhunk://#diff-831ff69f21b3a3702b066efd03c316febd2b35c3391754c5e72dc1068e9321e7L95-R95) [[8]](diffhunk://#diff-831ff69f21b3a3702b066efd03c316febd2b35c3391754c5e72dc1068e9321e7L106-R106)
  - `consistent-strong-style.md` [[1]](diffhunk://#diff-090dd7d79412d0dd6975f2d5d649f4b48939d6d4797bc266e4348bd2d1cdb32eL19-R19) [[2]](diffhunk://#diff-090dd7d79412d0dd6975f2d5d649f4b48939d6d4797bc266e4348bd2d1cdb32eL33-R33) [[3]](diffhunk://#diff-090dd7d79412d0dd6975f2d5d649f4b48939d6d4797bc266e4348bd2d1cdb32eL49-R49) [[4]](diffhunk://#diff-090dd7d79412d0dd6975f2d5d649f4b48939d6d4797bc266e4348bd2d1cdb32eL60-R60) [[5]](diffhunk://#diff-090dd7d79412d0dd6975f2d5d649f4b48939d6d4797bc266e4348bd2d1cdb32eL75-R75) [[6]](diffhunk://#diff-090dd7d79412d0dd6975f2d5d649f4b48939d6d4797bc266e4348bd2d1cdb32eL84-R84) [[7]](diffhunk://#diff-090dd7d79412d0dd6975f2d5d649f4b48939d6d4797bc266e4348bd2d1cdb32eL95-R95) [[8]](diffhunk://#diff-090dd7d79412d0dd6975f2d5d649f4b48939d6d4797bc266e4348bd2d1cdb32eL106-R106)