### PR TITLE
fix(eslint-markdown): build output location

### DIFF
--- a/packages/eslint-markdown/tsconfig.json
+++ b/packages/eslint-markdown/tsconfig.json
@@ -36,7 +36,6 @@
     /* Modules */
     "module": "NodeNext",
     "moduleResolution": "nodenext",
-    "rootDir": ".",
 
     /* Emit */
     "declaration": true,

--- a/packages/eslint-markdown/tsconfig.test.json
+++ b/packages/eslint-markdown/tsconfig.test.json
@@ -6,6 +6,9 @@
     /* Type Checking */
     "noUnusedParameters": false, // Turning it off since it's a test.
 
+    /* Modules */
+    "rootDir": ".",
+
     /* Emit */
     "noEmit": true
   }


### PR DESCRIPTION
This pull request makes minor adjustments to TypeScript configuration files for the `eslint-markdown` package, specifically regarding the `rootDir` setting.

- In `tsconfig.json`, the `rootDir` option was removed, which may affect how TypeScript determines the root directory for source files.
- In `tsconfig.test.json`, the `rootDir` option was explicitly added and set to `"."`, clarifying the root directory for test files.