### PR TITLE
chore(release): bump package versions from `v0.6.0` to `v0.6.1` (`patch`)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "npm-eslint-markdown",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "npm-eslint-markdown",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "workspaces": [
         ".",
         "packages/*",
@@ -18,7 +18,7 @@
         "editorconfig-checker": "^6.1.1",
         "eslint": "^9.39.4",
         "eslint-config-bananass": "^0.6.1",
-        "eslint-markdown": "^0.6.0",
+        "eslint-markdown": "^0.6.1",
         "husky": "^9.1.7",
         "lint-staged": "^16.4.0",
         "markdownlint-cli": "^0.48.0",
@@ -10180,7 +10180,7 @@
       }
     },
     "packages/eslint-markdown": {
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "@eslint/markdown": "^7.5.1",
@@ -10212,7 +10212,7 @@
         "@codecov/vite-plugin": "^1.9.1",
         "@shikijs/transformers": "^3.20.0",
         "@shikijs/vitepress-twoslash": "^3.20.0",
-        "eslint-markdown": "^0.6.0",
+        "eslint-markdown": "^0.6.1",
         "twoslash-eslint": "^0.3.4",
         "vitepress": "^2.0.0-alpha.15",
         "vitepress-plugin-group-icons": "^1.7.3"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "npm-eslint-markdown",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "packageManager": "npm@11.11.0",
   "engines": {
     "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
@@ -40,7 +40,7 @@
     "editorconfig-checker": "^6.1.1",
     "eslint": "^9.39.4",
     "eslint-config-bananass": "^0.6.1",
-    "eslint-markdown": "^0.6.0",
+    "eslint-markdown": "^0.6.1",
     "husky": "^9.1.7",
     "lint-staged": "^16.4.0",
     "markdownlint-cli": "^0.48.0",

--- a/packages/eslint-markdown/package.json
+++ b/packages/eslint-markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-markdown",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "description": "Lint your Markdown with ESLint.🛠️",
   "exports": {

--- a/website/package.json
+++ b/website/package.json
@@ -11,7 +11,7 @@
     "@codecov/vite-plugin": "^1.9.1",
     "@shikijs/transformers": "^3.20.0",
     "@shikijs/vitepress-twoslash": "^3.20.0",
-    "eslint-markdown": "^0.6.0",
+    "eslint-markdown": "^0.6.1",
     "twoslash-eslint": "^0.3.4",
     "vitepress": "^2.0.0-alpha.15",
     "vitepress-plugin-group-icons": "^1.7.3"


### PR DESCRIPTION
## Release Information: `v0.6.1`

New release of `lumirlumir/npm-eslint-markdown` has arrived! :tada:

This PR bumps the package versions from `v0.6.0` to `v0.6.1` (`patch`).

See [Actions](https://github.com/lumirlumir/npm-eslint-markdown/actions/runs/24141547034) for more details.

| Info        | Value                      |
| ----------- | -------------------------- |
| Repository  | `lumirlumir/npm-eslint-markdown` |
| SEMVER      | `patch`     |
| Pre ID      | `canary`      |
| Short SHA   | 81fa1d2       |
| Old Version | `v0.6.0`  |
| New Version | `v0.6.1`  |

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### :bug: Bug Fixes
* fix(eslint-markdown): recognize blockquotes in `blankLineAbove` and `blankLineBelow` in `consistent-code-style` rule by @lumirlumir in https://github.com/lumirlumir/npm-eslint-markdown/pull/542
### :toolbox: Chores
* chore(sync-server): update `dependabot`, `.gitignore` and bump `codecov/codecov-action` to v6 by @lumirlumir in https://github.com/lumirlumir/npm-eslint-markdown/pull/535
* chore(*): use TypeScript v6 by @lumirlumir in https://github.com/lumirlumir/npm-eslint-markdown/pull/533
* chore(*): update ignore file patterns by @lumirlumir in https://github.com/lumirlumir/npm-eslint-markdown/pull/541
### :arrow_up: Dependency Updates
* chore(deps-dev): bump lint-staged from 16.3.3 to 16.4.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-markdown/pull/524
* chore(deps): bump marocchino/sticky-pull-request-comment from 2 to 3 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-markdown/pull/523
* chore(deps-dev): bump flatted from 3.3.3 to 3.4.2 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-markdown/pull/525
* chore(deps): bump picomatch by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-markdown/pull/529
* chore(deps-dev): bump the dev-dependencies group across 2 directories with 2 updates by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-markdown/pull/540


**Full Changelog**: https://github.com/lumirlumir/npm-eslint-markdown/compare/v0.6.0...v0.6.1