### PR TITLE
chore(*): rename github actions workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: test-cross-platform
+name: test
 
 on:
   push:
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: ${{ !contains(github.ref, 'main') }}
 
 jobs:
-  test-cross-platform:
+  cross-platform:
     strategy:
       fail-fast: false
       matrix:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # eslint-markdown
 
-[![lint](https://img.shields.io/github/actions/workflow/status/lumirlumir/npm-eslint-markdown/lint.yml?label=lint&color=6358d4&labelColor=333333&logo=github)](https://github.com/lumirlumir/npm-eslint-markdown/actions/workflows/lint.yml)
+[![ci](https://img.shields.io/github/actions/workflow/status/lumirlumir/npm-eslint-markdown/ci.yml?label=ci&color=6358d4&labelColor=333333&logo=github)](https://github.com/lumirlumir/npm-eslint-markdown/actions/workflows/ci.yml)
 [![test](https://img.shields.io/github/actions/workflow/status/lumirlumir/npm-eslint-markdown/test.yml?label=test&color=6358d4&labelColor=333333&logo=github)](https://github.com/lumirlumir/npm-eslint-markdown/actions/workflows/test.yml)
-[![test-cross-platform](https://img.shields.io/github/actions/workflow/status/lumirlumir/npm-eslint-markdown/test-cross-platform.yml?label=test-cross-platform&color=6358d4&labelColor=333333&logo=github)](https://github.com/lumirlumir/npm-eslint-markdown/actions/workflows/test-cross-platform.yml)
 [![codecov](https://img.shields.io/codecov/c/gh/lumirlumir/npm-eslint-markdown?token=LJMUst9eR3&label=Codecov&color=6358d4&labelColor=333333&logo=codecov)](https://codecov.io/gh/lumirlumir/npm-eslint-markdown)
 ![Node Current](https://img.shields.io/node/v/eslint-markdown?color=6358d4&labelColor=333333&logo=node.js)
 


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow and the project README to simplify and clarify CI status reporting. The main changes include renaming the cross-platform test workflow and updating the README badges to reflect these changes.

**Workflow and CI updates:**

* Renamed the workflow file from `.github/workflows/test-cross-platform.yml` to `.github/workflows/test.yml` and updated the workflow name from `test-cross-platform` to `test` for clarity.
* Changed the job name in the workflow from `test-cross-platform` to `cross-platform` to match the new naming convention.

**README badge updates:**

* Updated the README to remove the outdated `test-cross-platform` badge and ensure badges reflect the new workflow names, including updating the lint badge to a CI badge.