### PR TITLE
chore(release): bump package versions from `v0.6.1` to `v0.7.0` (`minor`)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "npm-eslint-markdown",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "npm-eslint-markdown",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "workspaces": [
         ".",
         "packages/*",
@@ -18,7 +18,7 @@
         "editorconfig-checker": "^6.1.1",
         "eslint": "^9.39.4",
         "eslint-config-bananass": "^0.6.1",
-        "eslint-markdown": "^0.6.1",
+        "eslint-markdown": "^0.7.0",
         "husky": "^9.1.7",
         "lint-staged": "^16.4.0",
         "markdownlint-cli": "^0.48.0",
@@ -10144,7 +10144,7 @@
       }
     },
     "packages/eslint-markdown": {
-      "version": "0.6.1",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@eslint/markdown": "^7.5.1",
@@ -10176,7 +10176,7 @@
         "@codecov/vite-plugin": "^2.0.1",
         "@shikijs/transformers": "^3.20.0",
         "@shikijs/vitepress-twoslash": "^3.20.0",
-        "eslint-markdown": "^0.6.1",
+        "eslint-markdown": "^0.7.0",
         "twoslash-eslint": "^0.3.4",
         "vitepress": "^2.0.0-alpha.15",
         "vitepress-plugin-group-icons": "^1.7.5"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "npm-eslint-markdown",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "type": "module",
   "packageManager": "npm@11.11.0",
   "engines": {
@@ -41,7 +41,7 @@
     "editorconfig-checker": "^6.1.1",
     "eslint": "^9.39.4",
     "eslint-config-bananass": "^0.6.1",
-    "eslint-markdown": "^0.6.1",
+    "eslint-markdown": "^0.7.0",
     "husky": "^9.1.7",
     "lint-staged": "^16.4.0",
     "markdownlint-cli": "^0.48.0",

--- a/packages/eslint-markdown/package.json
+++ b/packages/eslint-markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-markdown",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "type": "module",
   "description": "Lint your Markdown with ESLint.🛠️",
   "exports": {

--- a/website/package.json
+++ b/website/package.json
@@ -11,7 +11,7 @@
     "@codecov/vite-plugin": "^2.0.1",
     "@shikijs/transformers": "^3.20.0",
     "@shikijs/vitepress-twoslash": "^3.20.0",
-    "eslint-markdown": "^0.6.1",
+    "eslint-markdown": "^0.7.0",
     "twoslash-eslint": "^0.3.4",
     "vitepress": "^2.0.0-alpha.15",
     "vitepress-plugin-group-icons": "^1.7.5"


### PR DESCRIPTION
## Release Information: `v0.7.0`

New release of `lumirlumir/npm-eslint-markdown` has arrived! :tada:

This PR bumps the package versions from `v0.6.1` to `v0.7.0` (`minor`).

See [Actions](https://github.com/lumirlumir/npm-eslint-markdown/actions/runs/24929817026) for more details.

| Info        | Value                      |
| ----------- | -------------------------- |
| Repository  | `lumirlumir/npm-eslint-markdown` |
| SEMVER      | `minor`     |
| Pre ID      | `canary`      |
| Short SHA   | 75b29d2       |
| Old Version | `v0.6.1`  |
| New Version | `v0.7.0`  |

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### :sparkles: Features
* feat(eslint-markdown): add `no-double-punctuation` rule by @Copilot in https://github.com/lumirlumir/npm-eslint-markdown/pull/547
### :toolbox: Chores
* chore(sync-server): update CI files and rename config files to use `.js` by @lumirlumir in https://github.com/lumirlumir/npm-eslint-markdown/pull/552
* chore(*): rename github actions workflow by @lumirlumir in https://github.com/lumirlumir/npm-eslint-markdown/pull/556
### :arrows_counterclockwise: Continuous Integrations
* ci(sync-server): reestablish cache strategy in CI for a faster speed by @lumirlumir in https://github.com/lumirlumir/npm-eslint-markdown/pull/546
* ci(*): (perf) remove unnecessary `npx` prefixes by @lumirlumir in https://github.com/lumirlumir/npm-eslint-markdown/pull/551
* ci(sync-server): merge lint and test workflow configs into ci by @lumirlumir in https://github.com/lumirlumir/npm-eslint-markdown/pull/553
### :arrow_up: Dependency Updates
* chore(deps-dev): bump prettier from 3.8.1 to 3.8.2 in the dev-dependencies group across 1 directory by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-markdown/pull/545
* chore(deps-dev): bump the dev-dependencies group across 2 directories with 2 updates by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-markdown/pull/548
* chore(deps-dev): bump the dev-dependencies group across 2 directories with 2 updates by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-markdown/pull/549
* chore(deps-dev): bump typescript from 6.0.2 to 6.0.3 in the dev-dependencies group across 1 directory by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-markdown/pull/550
* chore(deps): bump parse5 from 8.0.0 to 8.0.1 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-markdown/pull/554


**Full Changelog**: https://github.com/lumirlumir/npm-eslint-markdown/compare/v0.6.1...v0.7.0