### PR TITLE
feat(eslint-markdown): add `allow` option to `no-emoji`

### DIFF
--- a/packages/eslint-markdown/src/rules/no-emoji.js
+++ b/packages/eslint-markdown/src/rules/no-emoji.js
@@ -15,7 +15,7 @@ import { URL_RULE_DOCS } from '../core/constants.js';
 
 /**
  * @import { RuleModule } from '../core/types.js';
- * @typedef {[]} RuleOptions
+ * @typedef {[{ allow: string[] }]} RuleOptions
  * @typedef {'noEmoji'} MessageIds
  */
 
@@ -41,6 +41,28 @@ export default {
       stylistic: false,
     },
 
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          allow: {
+            type: 'array',
+            items: {
+              type: 'string',
+            },
+            uniqueItems: true,
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+
+    defaultOptions: [
+      {
+        allow: [],
+      },
+    ],
+
     messages: {
       noEmoji: 'Emojis are not allowed.',
     },
@@ -52,6 +74,7 @@ export default {
 
   create(context) {
     const { sourceCode } = context;
+    const [{ allow }] = context.options;
 
     return {
       text(node) {
@@ -59,8 +82,12 @@ export default {
         const matches = sourceCode.getText(node).matchAll(emojiRegex);
 
         for (const match of matches) {
+          const emoji = match[0];
+
+          if (allow.includes(emoji)) continue;
+
           const startOffset = nodeStartOffset + match.index;
-          const endOffset = startOffset + match[0].length;
+          const endOffset = startOffset + emoji.length;
 
           context.report({
             loc: {

--- a/packages/eslint-markdown/src/rules/no-emoji.test.js
+++ b/packages/eslint-markdown/src/rules/no-emoji.test.js
@@ -28,6 +28,26 @@ ruleTester('no-emoji', rule, {
       name: 'Text without emojis',
       code: 'Hello, world!',
     },
+
+    // Options
+    {
+      name: '`allow` option - 1',
+      code: 'Hello, 😄!',
+      options: [
+        {
+          allow: ['😄'],
+        },
+      ],
+    },
+    {
+      name: '`allow` option - 2',
+      code: 'Hello, 😄 and 🦄!',
+      options: [
+        {
+          allow: ['😄', '🦄'],
+        },
+      ],
+    },
   ],
 
   invalid: [
@@ -99,6 +119,27 @@ ruleTester('no-emoji', rule, {
           column: 3,
           endLine: 2,
           endColumn: 5,
+        },
+      ],
+    },
+
+    // Options
+    {
+      // 😄's length is 2, 🦄's length is 2.
+      name: '`allow` option - 1',
+      code: 'Hello, 😄 and 🦄!',
+      options: [
+        {
+          allow: ['😄'],
+        },
+      ],
+      errors: [
+        {
+          messageId: 'noEmoji',
+          line: 1,
+          column: 15,
+          endLine: 1,
+          endColumn: 17,
         },
       ],
     },

--- a/website/docs/rules/no-emoji.md
+++ b/website/docs/rules/no-emoji.md
@@ -45,9 +45,29 @@ Unicorn :unicorn:
 +1 :+1:
 ```
 
+#### With `{ allow: ['😃', '🦄'] }` Option
+
+```md eslint-check
+<!-- eslint md/no-emoji: ['error', { allow: ['😃', '🦄'] }] -->
+
+Smiley 😃
+Unicorn 🦄
++1 :+1:
+```
+
 ## Options
 
-No options are available for this rule.
+```js
+'md/no-emoji': ['error', {
+  allow: [],
+}]
+```
+
+### `allow`
+
+> Type: `string[]` / Default: `[]`
+
+When specified, specific emoji sequences are allowed if they match one of the strings in this array. This is useful when a document intentionally uses a small set of raw Unicode emojis while still disallowing all others.
 
 ## Limitations
 


### PR DESCRIPTION
## summary

Add an `allow` option to `md/no-emoji` so specific raw Unicode emoji sequences can be exempted while all other emojis remain disallowed.

## scope

- `packages/eslint-markdown/src/rules/no-emoji.js`
- `packages/eslint-markdown/src/rules/no-emoji.test.js`
- `website/docs/rules/no-emoji.md`

## validation

- `npm run test` passed
- `npm run build` passed
- `npm run lint` passed

## notes

- The `allow` option follows the existing string-array option pattern used by related rules.