### PR TITLE
chore(release): bump package versions from `v0.7.0` to `v0.8.0` (`minor`)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "npm-eslint-markdown",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "npm-eslint-markdown",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "workspaces": [
         ".",
         "packages/*",
@@ -18,7 +18,7 @@
         "editorconfig-checker": "^6.1.1",
         "eslint": "^9.39.4",
         "eslint-config-bananass": "^0.6.1",
-        "eslint-markdown": "^0.7.0",
+        "eslint-markdown": "^0.8.0",
         "husky": "^9.1.7",
         "lint-staged": "^16.4.0",
         "markdownlint-cli": "^0.48.0",
@@ -1538,9 +1538,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1555,9 +1552,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1572,9 +1566,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1589,9 +1580,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1606,9 +1594,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1623,9 +1608,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1640,9 +1622,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1657,9 +1636,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1674,9 +1650,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1691,9 +1664,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1708,9 +1678,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1725,9 +1692,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1742,9 +1706,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10228,7 +10189,7 @@
       }
     },
     "packages/eslint-markdown": {
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "@eslint/markdown": "^7.5.1",
@@ -10260,7 +10221,7 @@
         "@codecov/vite-plugin": "^2.0.1",
         "@shikijs/transformers": "^3.20.0",
         "@shikijs/vitepress-twoslash": "^3.20.0",
-        "eslint-markdown": "^0.7.0",
+        "eslint-markdown": "^0.8.0",
         "twoslash-eslint": "^0.3.4",
         "vitepress": "^2.0.0-alpha.15",
         "vitepress-plugin-group-icons": "^1.7.5"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "npm-eslint-markdown",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "type": "module",
   "packageManager": "npm@11.11.0",
   "engines": {
@@ -41,7 +41,7 @@
     "editorconfig-checker": "^6.1.1",
     "eslint": "^9.39.4",
     "eslint-config-bananass": "^0.6.1",
-    "eslint-markdown": "^0.7.0",
+    "eslint-markdown": "^0.8.0",
     "husky": "^9.1.7",
     "lint-staged": "^16.4.0",
     "markdownlint-cli": "^0.48.0",

--- a/packages/eslint-markdown/package.json
+++ b/packages/eslint-markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-markdown",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "type": "module",
   "description": "Lint your Markdown with ESLint.🛠️",
   "exports": {

--- a/website/package.json
+++ b/website/package.json
@@ -11,7 +11,7 @@
     "@codecov/vite-plugin": "^2.0.1",
     "@shikijs/transformers": "^3.20.0",
     "@shikijs/vitepress-twoslash": "^3.20.0",
-    "eslint-markdown": "^0.7.0",
+    "eslint-markdown": "^0.8.0",
     "twoslash-eslint": "^0.3.4",
     "vitepress": "^2.0.0-alpha.15",
     "vitepress-plugin-group-icons": "^1.7.5"


### PR DESCRIPTION
## Release Information: `v0.8.0`

New release of `lumirlumir/npm-eslint-markdown` has arrived! :tada:

This PR bumps the package versions from `v0.7.0` to `v0.8.0` (`minor`).

See [Actions](https://github.com/lumirlumir/npm-eslint-markdown/actions/runs/25281464731) for more details.

| Info        | Value                      |
| ----------- | -------------------------- |
| Repository  | `lumirlumir/npm-eslint-markdown` |
| SEMVER      | `minor`     |
| Pre ID      | `canary`      |
| Short SHA   | f030e86       |
| Old Version | `v0.7.0`  |
| New Version | `v0.8.0`  |

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### :sparkles: Features
* feat(eslint-markdown): add `allow` option to `no-emoji` by @lumirlumir in https://github.com/lumirlumir/npm-eslint-markdown/pull/560
* feat(eslint-markdown): add autofix for `no-git-conflict-marker` by @lumirlumir in https://github.com/lumirlumir/npm-eslint-markdown/pull/562
### :arrow_up: Dependency Updates
* chore(deps-dev): bump postcss from 8.5.6 to 8.5.10 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-markdown/pull/559
* chore(deps-dev): bump rollup from 4.53.3 to 4.60.2 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-markdown/pull/558


**Full Changelog**: https://github.com/lumirlumir/npm-eslint-markdown/compare/v0.7.0...v0.8.0