### PR TITLE
feat(eslint-markdown): add auto-fix and suggestions to `no-double-punctuation`

### DIFF
--- a/packages/eslint-markdown/src/rules/no-double-punctuation.js
+++ b/packages/eslint-markdown/src/rules/no-double-punctuation.js
@@ -105,7 +105,7 @@ export default {
           if (allow.includes(punctuation)) continue;
 
           const [leftPunctuation, rightPunctuation] = punctuation;
-          const violoation = /** @type {const} */ ({
+          const violation = /** @type {const} */ ({
             loc: {
               start: sourceCode.getLocFromIndex(startOffset),
               end: sourceCode.getLocFromIndex(endOffset),
@@ -120,7 +120,7 @@ export default {
 
           if (leftPunctuation === rightPunctuation) {
             context.report({
-              ...violoation,
+              ...violation,
 
               fix(fixer) {
                 return fixer.replaceTextRange([startOffset, endOffset], leftPunctuation);
@@ -128,7 +128,7 @@ export default {
             });
           } else {
             context.report({
-              ...violoation,
+              ...violation,
 
               suggest: [
                 {

--- a/packages/eslint-markdown/src/rules/no-double-punctuation.js
+++ b/packages/eslint-markdown/src/rules/no-double-punctuation.js
@@ -16,7 +16,7 @@ import { URL_RULE_DOCS } from '../core/constants.js';
 /**
  * @import { RuleModule } from '../core/types.js';
  * @typedef {[{ allow: string[] }]} RuleOptions
- * @typedef {'noDoublePunctuation'} MessageIds
+ * @typedef {'noDoublePunctuation' | 'suggestReplaceWithLeft' | 'suggestReplaceWithRight'} MessageIds
  */
 
 // --------------------------------------------------------------------------------
@@ -45,6 +45,10 @@ export default {
       stylistic: false,
     },
 
+    fixable: 'code',
+
+    hasSuggestions: true,
+
     schema: [
       {
         type: 'object',
@@ -72,6 +76,10 @@ export default {
 
     messages: {
       noDoublePunctuation: 'Double punctuation mark `{{ punctuation }}` is not allowed.',
+      suggestReplaceWithLeft:
+        'Replace `{{ punctuation }}` with the left punctuation mark `{{ leftPunctuation }}`.',
+      suggestReplaceWithRight:
+        'Replace `{{ punctuation }}` with the right punctuation mark `{{ rightPunctuation }}`.',
     },
 
     language: 'markdown',
@@ -96,7 +104,8 @@ export default {
 
           if (allow.includes(punctuation)) continue;
 
-          context.report({
+          const [leftPunctuation, rightPunctuation] = punctuation;
+          const violoation = /** @type {const} */ ({
             loc: {
               start: sourceCode.getLocFromIndex(startOffset),
               end: sourceCode.getLocFromIndex(endOffset),
@@ -108,6 +117,53 @@ export default {
 
             messageId: 'noDoublePunctuation',
           });
+
+          if (leftPunctuation === rightPunctuation) {
+            context.report({
+              ...violoation,
+
+              fix(fixer) {
+                return fixer.replaceTextRange([startOffset, endOffset], leftPunctuation);
+              },
+            });
+          } else {
+            context.report({
+              ...violoation,
+
+              suggest: [
+                {
+                  messageId: 'suggestReplaceWithLeft',
+
+                  data: {
+                    punctuation,
+                    leftPunctuation,
+                  },
+
+                  fix(fixer) {
+                    return fixer.replaceTextRange(
+                      [startOffset, endOffset],
+                      leftPunctuation,
+                    );
+                  },
+                },
+                {
+                  messageId: 'suggestReplaceWithRight',
+
+                  data: {
+                    punctuation,
+                    rightPunctuation,
+                  },
+
+                  fix(fixer) {
+                    return fixer.replaceTextRange(
+                      [startOffset, endOffset],
+                      rightPunctuation,
+                    );
+                  },
+                },
+              ],
+            });
+          }
         }
       },
     };

--- a/packages/eslint-markdown/src/rules/no-double-punctuation.test.js
+++ b/packages/eslint-markdown/src/rules/no-double-punctuation.test.js
@@ -66,6 +66,7 @@ ruleTester('no-double-punctuation', rule, {
   invalid: [
     {
       code: '!!',
+      output: '!',
       errors: [
         {
           messageId: 'noDoublePunctuation',
@@ -76,11 +77,13 @@ ruleTester('no-double-punctuation', rule, {
           data: {
             punctuation: '!!',
           },
+          suggestions: undefined,
         },
       ],
     },
     {
       code: ',,',
+      output: ',',
       errors: [
         {
           messageId: 'noDoublePunctuation',
@@ -91,11 +94,13 @@ ruleTester('no-double-punctuation', rule, {
           data: {
             punctuation: ',,',
           },
+          suggestions: undefined,
         },
       ],
     },
     {
       code: '..',
+      output: '.',
       errors: [
         {
           messageId: 'noDoublePunctuation',
@@ -106,11 +111,13 @@ ruleTester('no-double-punctuation', rule, {
           data: {
             punctuation: '..',
           },
+          suggestions: undefined,
         },
       ],
     },
     {
       code: '::',
+      output: ':',
       errors: [
         {
           messageId: 'noDoublePunctuation',
@@ -121,11 +128,13 @@ ruleTester('no-double-punctuation', rule, {
           data: {
             punctuation: '::',
           },
+          suggestions: undefined,
         },
       ],
     },
     {
       code: ';;',
+      output: ';',
       errors: [
         {
           messageId: 'noDoublePunctuation',
@@ -136,11 +145,13 @@ ruleTester('no-double-punctuation', rule, {
           data: {
             punctuation: ';;',
           },
+          suggestions: undefined,
         },
       ],
     },
     {
       code: '??',
+      output: '?',
       errors: [
         {
           messageId: 'noDoublePunctuation',
@@ -151,11 +162,13 @@ ruleTester('no-double-punctuation', rule, {
           data: {
             punctuation: '??',
           },
+          suggestions: undefined,
         },
       ],
     },
     {
       code: 'Foo!!',
+      output: 'Foo!',
       errors: [
         {
           messageId: 'noDoublePunctuation',
@@ -166,6 +179,7 @@ ruleTester('no-double-punctuation', rule, {
           data: {
             punctuation: '!!',
           },
+          suggestions: undefined,
         },
       ],
     },
@@ -181,6 +195,24 @@ ruleTester('no-double-punctuation', rule, {
           data: {
             punctuation: '?!',
           },
+          suggestions: [
+            {
+              output: 'Foo?',
+              messageId: 'suggestReplaceWithLeft',
+              data: {
+                punctuation: '?!',
+                leftPunctuation: '?',
+              },
+            },
+            {
+              output: 'Foo!',
+              messageId: 'suggestReplaceWithRight',
+              data: {
+                punctuation: '?!',
+                rightPunctuation: '!',
+              },
+            },
+          ],
         },
       ],
     },
@@ -190,6 +222,11 @@ ruleTester('no-double-punctuation', rule, {
 > Quote::
 
 - Item??`,
+      output: `# Heading!
+
+> Quote:
+
+- Item?`,
       errors: [
         {
           messageId: 'noDoublePunctuation',
@@ -200,6 +237,7 @@ ruleTester('no-double-punctuation', rule, {
           data: {
             punctuation: '!!',
           },
+          suggestions: undefined,
         },
         {
           messageId: 'noDoublePunctuation',
@@ -210,6 +248,7 @@ ruleTester('no-double-punctuation', rule, {
           data: {
             punctuation: '::',
           },
+          suggestions: undefined,
         },
         {
           messageId: 'noDoublePunctuation',
@@ -220,11 +259,13 @@ ruleTester('no-double-punctuation', rule, {
           data: {
             punctuation: '??',
           },
+          suggestions: undefined,
         },
       ],
     },
     {
       code: '**Strong!!** and *Emphasis??* and [Link::](https://example.com)',
+      output: '**Strong!** and *Emphasis?* and [Link:](https://example.com)',
       errors: [
         {
           messageId: 'noDoublePunctuation',
@@ -235,6 +276,7 @@ ruleTester('no-double-punctuation', rule, {
           data: {
             punctuation: '!!',
           },
+          suggestions: undefined,
         },
         {
           messageId: 'noDoublePunctuation',
@@ -245,6 +287,7 @@ ruleTester('no-double-punctuation', rule, {
           data: {
             punctuation: '??',
           },
+          suggestions: undefined,
         },
         {
           messageId: 'noDoublePunctuation',
@@ -255,11 +298,13 @@ ruleTester('no-double-punctuation', rule, {
           data: {
             punctuation: '::',
           },
+          suggestions: undefined,
         },
       ],
     },
     {
       code: 'Foo!! `code??` Bar?!',
+      output: 'Foo! `code??` Bar?!',
       errors: [
         {
           messageId: 'noDoublePunctuation',
@@ -270,6 +315,7 @@ ruleTester('no-double-punctuation', rule, {
           data: {
             punctuation: '!!',
           },
+          suggestions: undefined,
         },
         {
           messageId: 'noDoublePunctuation',
@@ -280,12 +326,33 @@ ruleTester('no-double-punctuation', rule, {
           data: {
             punctuation: '?!',
           },
+          suggestions: [
+            {
+              output: 'Foo!! `code??` Bar?',
+              messageId: 'suggestReplaceWithLeft',
+              data: {
+                punctuation: '?!',
+                leftPunctuation: '?',
+              },
+            },
+            {
+              output: 'Foo!! `code??` Bar!',
+              messageId: 'suggestReplaceWithRight',
+              data: {
+                punctuation: '?!',
+                rightPunctuation: '!',
+              },
+            },
+          ],
         },
       ],
     },
     {
       code: `Foo!!
 Bar..
+Baz;:`,
+      output: `Foo!
+Bar.
 Baz;:`,
       errors: [
         {
@@ -297,6 +364,7 @@ Baz;:`,
           data: {
             punctuation: '!!',
           },
+          suggestions: undefined,
         },
         {
           messageId: 'noDoublePunctuation',
@@ -307,6 +375,7 @@ Baz;:`,
           data: {
             punctuation: '..',
           },
+          suggestions: undefined,
         },
         {
           messageId: 'noDoublePunctuation',
@@ -317,6 +386,28 @@ Baz;:`,
           data: {
             punctuation: ';:',
           },
+          suggestions: [
+            {
+              output: `Foo!!
+Bar..
+Baz;`,
+              messageId: 'suggestReplaceWithLeft',
+              data: {
+                punctuation: ';:',
+                leftPunctuation: ';',
+              },
+            },
+            {
+              output: `Foo!!
+Bar..
+Baz:`,
+              messageId: 'suggestReplaceWithRight',
+              data: {
+                punctuation: ';:',
+                rightPunctuation: ':',
+              },
+            },
+          ],
         },
       ],
     },
@@ -339,6 +430,24 @@ Baz;:`,
           data: {
             punctuation: '?!',
           },
+          suggestions: [
+            {
+              output: 'Foo!! Bar?',
+              messageId: 'suggestReplaceWithLeft',
+              data: {
+                punctuation: '?!',
+                leftPunctuation: '?',
+              },
+            },
+            {
+              output: 'Foo!! Bar!',
+              messageId: 'suggestReplaceWithRight',
+              data: {
+                punctuation: '?!',
+                rightPunctuation: '!',
+              },
+            },
+          ],
         },
       ],
     },

--- a/website/.vitepress/config.js
+++ b/website/.vitepress/config.js
@@ -306,7 +306,7 @@ export default defineConfig({
   ${(rule.meta.docs.recommended ?? false) ? '<code class="rule-emoji">✅ Recommended</code>' : ''}
   ${(rule.meta.docs.stylistic ?? false) ? '<code class="rule-emoji">🎨 Stylistic</code>' : ''}
   ${(rule.meta.fixable ?? false) ? '<code class="rule-emoji">🔧 Fixable</code>' : ''}
-  ${(rule.meta.docs.suggestion ?? false) ? '<code class="rule-emoji">💡 Suggestion</code>' : ''}
+  ${(rule.meta.hasSuggestions ?? false) ? '<code class="rule-emoji">💡 Suggestion</code>' : ''}
   ${(rule.meta.dialects.includes('commonmark') ?? false) ? '<code class="rule-emoji">⭐ CommonMark</code>' : ''}
   ${(rule.meta.dialects.includes('gfm') ?? false) ? '<code class="rule-emoji">🌟 GFM</code>' : ''}
 </p>

--- a/website/docs/rules/index.data.js
+++ b/website/docs/rules/index.data.js
@@ -37,7 +37,7 @@ const ruleMetas = Object.keys(rules).map(
       recommended: rules[rule].meta.docs.recommended ?? false,
       stylistic: rules[rule].meta.docs.stylistic ?? false,
       fixable: rules[rule].meta.fixable ?? false,
-      suggestion: rules[rule].meta.docs.suggestion ?? false,
+      suggestion: rules[rule].meta.hasSuggestions ?? false,
       commonmark: rules[rule].meta.dialects.includes('commonmark') ?? false,
       gfm: rules[rule].meta.dialects.includes('gfm') ?? false,
     }),

--- a/website/docs/rules/no-double-punctuation.md
+++ b/website/docs/rules/no-double-punctuation.md
@@ -68,6 +68,14 @@ Are you sure?!
 
 When `allow` is specified, the listed two-character punctuation patterns are ignored by this rule. This is useful when punctuation such as `!!` or `?!` is intentionally used for tone or emphasis instead of being treated as a typo.
 
+## Fix
+
+This rule provides a fix when two punctuation marks are the same by replacing the pair with a single punctuation mark. For example, `!!` is fixed to `!`, and `..` is fixed to `.`.
+
+## Suggestions
+
+This rule provides suggestions when the two punctuation marks are different. You can replace the pair with either the left punctuation mark or the right punctuation mark. For example, `?!` can be replaced with `?` or `!`.
+
 ## Prior Art
 
 - [`remark-lint-no-repeat-punctuation`](https://github.com/laysent/remark-lint-plugins/tree/HEAD/packages/remark-lint-no-repeat-punctuation#remark-lint-no-repeat-punctuation)

--- a/website/docs/rules/no-double-punctuation.md
+++ b/website/docs/rules/no-double-punctuation.md
@@ -72,7 +72,7 @@ When `allow` is specified, the listed two-character punctuation patterns are ign
 
 This rule provides a fix when two punctuation marks are the same by replacing the pair with a single punctuation mark. For example, `!!` is fixed to `!`, and `..` is fixed to `.`.
 
-## Suggestions
+## Suggestion
 
 This rule provides suggestions when the two punctuation marks are different. You can replace the pair with either the left punctuation mark or the right punctuation mark. For example, `?!` can be replaced with `?` or `!`.
 


### PR DESCRIPTION
This pull request enhances the `no-double-punctuation` rule in the `eslint-markdown` package by adding automatic fixes and suggestions for double punctuation issues in Markdown. Now, the rule can automatically fix repeated punctuation (like `!!` → `!`) and provide suggestions when the double punctuation consists of two different marks (like `?!`). The documentation and tests have also been updated to reflect these improvements.

**Rule enhancements:**

* Added automatic fix support for repeated punctuation marks (e.g., `!!` → `!`). [[1]](diffhunk://#diff-b226d77653ac2b722d6d7b8e6e5bcd2fcd443873ee337a5712e7e8ee9003f181R48-R51) [[2]](diffhunk://#diff-b226d77653ac2b722d6d7b8e6e5bcd2fcd443873ee337a5712e7e8ee9003f181R120-R166)
* Introduced suggestions for mixed double punctuation, allowing users to replace with either the left or right punctuation mark (e.g., `?!` → `?` or `!`). [[1]](diffhunk://#diff-b226d77653ac2b722d6d7b8e6e5bcd2fcd443873ee337a5712e7e8ee9003f181L19-R19) [[2]](diffhunk://#diff-b226d77653ac2b722d6d7b8e6e5bcd2fcd443873ee337a5712e7e8ee9003f181R79-R82) [[3]](diffhunk://#diff-b226d77653ac2b722d6d7b8e6e5bcd2fcd443873ee337a5712e7e8ee9003f181L99-R108) [[4]](diffhunk://#diff-b226d77653ac2b722d6d7b8e6e5bcd2fcd443873ee337a5712e7e8ee9003f181R120-R166)

**Testing improvements:**

* Updated and expanded test cases to verify both the automatic fixes and the new suggestions, ensuring correctness for a variety of punctuation scenarios. [[1]](diffhunk://#diff-eea321f29c333f4e6bdf68da6a7f9c7bea3e49e84b5659418f2003c2f46717a3R69) [[2]](diffhunk://#diff-eea321f29c333f4e6bdf68da6a7f9c7bea3e49e84b5659418f2003c2f46717a3R80-R86) [[3]](diffhunk://#diff-eea321f29c333f4e6bdf68da6a7f9c7bea3e49e84b5659418f2003c2f46717a3R97-R103) [[4]](diffhunk://#diff-eea321f29c333f4e6bdf68da6a7f9c7bea3e49e84b5659418f2003c2f46717a3R114-R120) [[5]](diffhunk://#diff-eea321f29c333f4e6bdf68da6a7f9c7bea3e49e84b5659418f2003c2f46717a3R131-R137) [[6]](diffhunk://#diff-eea321f29c333f4e6bdf68da6a7f9c7bea3e49e84b5659418f2003c2f46717a3R148-R154) [[7]](diffhunk://#diff-eea321f29c333f4e6bdf68da6a7f9c7bea3e49e84b5659418f2003c2f46717a3R165-R171) [[8]](diffhunk://#diff-eea321f29c333f4e6bdf68da6a7f9c7bea3e49e84b5659418f2003c2f46717a3R182) [[9]](diffhunk://#diff-eea321f29c333f4e6bdf68da6a7f9c7bea3e49e84b5659418f2003c2f46717a3R198-R215) [[10]](diffhunk://#diff-eea321f29c333f4e6bdf68da6a7f9c7bea3e49e84b5659418f2003c2f46717a3R225-R229) [[11]](diffhunk://#diff-eea321f29c333f4e6bdf68da6a7f9c7bea3e49e84b5659418f2003c2f46717a3R240) [[12]](diffhunk://#diff-eea321f29c333f4e6bdf68da6a7f9c7bea3e49e84b5659418f2003c2f46717a3R251) [[13]](diffhunk://#diff-eea321f29c333f4e6bdf68da6a7f9c7bea3e49e84b5659418f2003c2f46717a3R262-R268) [[14]](diffhunk://#diff-eea321f29c333f4e6bdf68da6a7f9c7bea3e49e84b5659418f2003c2f46717a3R279) [[15]](diffhunk://#diff-eea321f29c333f4e6bdf68da6a7f9c7bea3e49e84b5659418f2003c2f46717a3R290) [[16]](diffhunk://#diff-eea321f29c333f4e6bdf68da6a7f9c7bea3e49e84b5659418f2003c2f46717a3R301-R307) [[17]](diffhunk://#diff-eea321f29c333f4e6bdf68da6a7f9c7bea3e49e84b5659418f2003c2f46717a3R318) [[18]](diffhunk://#diff-eea321f29c333f4e6bdf68da6a7f9c7bea3e49e84b5659418f2003c2f46717a3R329-R355) [[19]](diffhunk://#diff-eea321f29c333f4e6bdf68da6a7f9c7bea3e49e84b5659418f2003c2f46717a3R367) [[20]](diffhunk://#diff-eea321f29c333f4e6bdf68da6a7f9c7bea3e49e84b5659418f2003c2f46717a3R378) [[21]](diffhunk://#diff-eea321f29c333f4e6bdf68da6a7f9c7bea3e49e84b5659418f2003c2f46717a3R389-R410) [[22]](diffhunk://#diff-eea321f29c333f4e6bdf68da6a7f9c7bea3e49e84b5659418f2003c2f46717a3R433-R450)

**Documentation updates:**

* Updated the rule documentation to describe the new fix and suggestion capabilities, providing clear examples for users.

**Website metadata:**

* Updated the rule metadata in the website docs to correctly reflect the new `hasSuggestions` property.