### PR TITLE
chore(eslint-markdown): remove unused dummy file

### DIFF
--- a/packages/eslint-markdown/src/rules/footnote-order.js
+++ b/packages/eslint-markdown/src/rules/footnote-order.js
@@ -1,2 +1,0 @@
-// TODO
-// https://github.com/textlint-rule/textlint-rule-footnote-order


### PR DESCRIPTION
This pull request removes a commented-out TODO referencing an external footnote order rule from the `footnote-order.js` file. No functional changes were made.