### PR TITLE
fix(eslint-markdown): exclude rule tester from package files

### DIFF
--- a/packages/eslint-markdown/package.json
+++ b/packages/eslint-markdown/package.json
@@ -26,6 +26,7 @@
     "LICENSE.md",
     "README.md",
     "!src/**/*.test.{js,ts}",
+    "!{src,build}/tests/**",
     "!**/fixtures/**"
   ],
   "keywords": [

--- a/packages/eslint-markdown/src/rules/allow-heading.test.js
+++ b/packages/eslint-markdown/src/rules/allow-heading.test.js
@@ -7,7 +7,7 @@
 // Import
 // --------------------------------------------------------------------------------
 
-import ruleTester from '../core/rule-tester.js';
+import ruleTester from '../tests/rule-tester.js';
 import rule from './allow-heading.js';
 
 // --------------------------------------------------------------------------------

--- a/packages/eslint-markdown/src/rules/allow-image-url.test.js
+++ b/packages/eslint-markdown/src/rules/allow-image-url.test.js
@@ -8,7 +8,7 @@
 // Import
 // --------------------------------------------------------------------------------
 
-import ruleTester from '../core/rule-tester.js';
+import ruleTester from '../tests/rule-tester.js';
 import rule from './allow-image-url.js';
 
 // --------------------------------------------------------------------------------

--- a/packages/eslint-markdown/src/rules/allow-link-url.test.js
+++ b/packages/eslint-markdown/src/rules/allow-link-url.test.js
@@ -8,7 +8,7 @@
 // Import
 // --------------------------------------------------------------------------------
 
-import ruleTester from '../core/rule-tester.js';
+import ruleTester from '../tests/rule-tester.js';
 import rule from './allow-link-url.js';
 
 // --------------------------------------------------------------------------------

--- a/packages/eslint-markdown/src/rules/code-lang-shorthand.test.js
+++ b/packages/eslint-markdown/src/rules/code-lang-shorthand.test.js
@@ -7,7 +7,7 @@
 // Import
 // --------------------------------------------------------------------------------
 
-import ruleTester from '../core/rule-tester.js';
+import ruleTester from '../tests/rule-tester.js';
 import rule from './code-lang-shorthand.js';
 
 // --------------------------------------------------------------------------------

--- a/packages/eslint-markdown/src/rules/consistent-code-style.test.js
+++ b/packages/eslint-markdown/src/rules/consistent-code-style.test.js
@@ -7,7 +7,7 @@
 // Import
 // --------------------------------------------------------------------------------
 
-import ruleTester from '../core/rule-tester.js';
+import ruleTester from '../tests/rule-tester.js';
 import rule from './consistent-code-style.js';
 
 // --------------------------------------------------------------------------------

--- a/packages/eslint-markdown/src/rules/consistent-delete-style.test.js
+++ b/packages/eslint-markdown/src/rules/consistent-delete-style.test.js
@@ -7,7 +7,7 @@
 // Import
 // --------------------------------------------------------------------------------
 
-import ruleTester from '../core/rule-tester.js';
+import ruleTester from '../tests/rule-tester.js';
 import rule from './consistent-delete-style.js';
 
 // --------------------------------------------------------------------------------

--- a/packages/eslint-markdown/src/rules/consistent-emphasis-style.test.js
+++ b/packages/eslint-markdown/src/rules/consistent-emphasis-style.test.js
@@ -7,7 +7,7 @@
 // Import
 // --------------------------------------------------------------------------------
 
-import ruleTester from '../core/rule-tester.js';
+import ruleTester from '../tests/rule-tester.js';
 import rule from './consistent-emphasis-style.js';
 
 // --------------------------------------------------------------------------------

--- a/packages/eslint-markdown/src/rules/consistent-inline-code-style.test.js
+++ b/packages/eslint-markdown/src/rules/consistent-inline-code-style.test.js
@@ -8,7 +8,7 @@
 // Import
 // --------------------------------------------------------------------------------
 
-import ruleTester from '../core/rule-tester.js';
+import ruleTester from '../tests/rule-tester.js';
 import rule from './consistent-inline-code-style.js';
 
 // --------------------------------------------------------------------------------

--- a/packages/eslint-markdown/src/rules/consistent-strong-style.test.js
+++ b/packages/eslint-markdown/src/rules/consistent-strong-style.test.js
@@ -7,7 +7,7 @@
 // Import
 // --------------------------------------------------------------------------------
 
-import ruleTester from '../core/rule-tester.js';
+import ruleTester from '../tests/rule-tester.js';
 import rule from './consistent-strong-style.js';
 
 // --------------------------------------------------------------------------------

--- a/packages/eslint-markdown/src/rules/consistent-thematic-break-style.test.js
+++ b/packages/eslint-markdown/src/rules/consistent-thematic-break-style.test.js
@@ -7,7 +7,7 @@
 // Import
 // --------------------------------------------------------------------------------
 
-import ruleTester from '../core/rule-tester.js';
+import ruleTester from '../tests/rule-tester.js';
 import rule from './consistent-thematic-break-style.js';
 
 // --------------------------------------------------------------------------------

--- a/packages/eslint-markdown/src/rules/consistent-unordered-list-style.test.js
+++ b/packages/eslint-markdown/src/rules/consistent-unordered-list-style.test.js
@@ -7,7 +7,7 @@
 // Import
 // --------------------------------------------------------------------------------
 
-import ruleTester from '../core/rule-tester.js';
+import ruleTester from '../tests/rule-tester.js';
 import rule from './consistent-unordered-list-style.js';
 
 // --------------------------------------------------------------------------------

--- a/packages/eslint-markdown/src/rules/en-capitalization.test.js
+++ b/packages/eslint-markdown/src/rules/en-capitalization.test.js
@@ -7,7 +7,7 @@
 // Import
 // --------------------------------------------------------------------------------
 
-import ruleTester from '../core/rule-tester.js';
+import ruleTester from '../tests/rule-tester.js';
 import rule from './en-capitalization.js';
 
 // --------------------------------------------------------------------------------

--- a/packages/eslint-markdown/src/rules/heading-id.test.js
+++ b/packages/eslint-markdown/src/rules/heading-id.test.js
@@ -7,7 +7,7 @@
 // Import
 // --------------------------------------------------------------------------------
 
-import ruleTester from '../core/rule-tester.js';
+import ruleTester from '../tests/rule-tester.js';
 import rule from './heading-id.js';
 
 // --------------------------------------------------------------------------------

--- a/packages/eslint-markdown/src/rules/no-bold-paragraph.test.js
+++ b/packages/eslint-markdown/src/rules/no-bold-paragraph.test.js
@@ -7,7 +7,7 @@
 // Import
 // --------------------------------------------------------------------------------
 
-import ruleTester from '../core/rule-tester.js';
+import ruleTester from '../tests/rule-tester.js';
 import rule from './no-bold-paragraph.js';
 
 // --------------------------------------------------------------------------------

--- a/packages/eslint-markdown/src/rules/no-control-character.test.js
+++ b/packages/eslint-markdown/src/rules/no-control-character.test.js
@@ -7,7 +7,7 @@
 // Import
 // --------------------------------------------------------------------------------
 
-import ruleTester from '../core/rule-tester.js';
+import ruleTester from '../tests/rule-tester.js';
 import rule from './no-control-character.js';
 
 // --------------------------------------------------------------------------------

--- a/packages/eslint-markdown/src/rules/no-curly-quote.test.js
+++ b/packages/eslint-markdown/src/rules/no-curly-quote.test.js
@@ -7,7 +7,7 @@
 // Import
 // --------------------------------------------------------------------------------
 
-import ruleTester from '../core/rule-tester.js';
+import ruleTester from '../tests/rule-tester.js';
 import rule from './no-curly-quote.js';
 
 // --------------------------------------------------------------------------------

--- a/packages/eslint-markdown/src/rules/no-double-punctuation.test.js
+++ b/packages/eslint-markdown/src/rules/no-double-punctuation.test.js
@@ -7,7 +7,7 @@
 // Import
 // --------------------------------------------------------------------------------
 
-import ruleTester from '../core/rule-tester.js';
+import ruleTester from '../tests/rule-tester.js';
 import rule from './no-double-punctuation.js';
 
 // --------------------------------------------------------------------------------

--- a/packages/eslint-markdown/src/rules/no-double-space.test.js
+++ b/packages/eslint-markdown/src/rules/no-double-space.test.js
@@ -7,7 +7,7 @@
 // Import
 // --------------------------------------------------------------------------------
 
-import ruleTester from '../core/rule-tester.js';
+import ruleTester from '../tests/rule-tester.js';
 import rule from './no-double-space.js';
 
 // --------------------------------------------------------------------------------

--- a/packages/eslint-markdown/src/rules/no-emoji.test.js
+++ b/packages/eslint-markdown/src/rules/no-emoji.test.js
@@ -7,7 +7,7 @@
 // Import
 // --------------------------------------------------------------------------------
 
-import ruleTester from '../core/rule-tester.js';
+import ruleTester from '../tests/rule-tester.js';
 import rule from './no-emoji.js';
 
 // --------------------------------------------------------------------------------

--- a/packages/eslint-markdown/src/rules/no-git-conflict-marker.test.js
+++ b/packages/eslint-markdown/src/rules/no-git-conflict-marker.test.js
@@ -7,7 +7,7 @@
 // Import
 // --------------------------------------------------------------------------------
 
-import ruleTester from '../core/rule-tester.js';
+import ruleTester from '../tests/rule-tester.js';
 import rule from './no-git-conflict-marker.js';
 
 // --------------------------------------------------------------------------------

--- a/packages/eslint-markdown/src/rules/no-irregular-dash.test.js
+++ b/packages/eslint-markdown/src/rules/no-irregular-dash.test.js
@@ -7,7 +7,7 @@
 // Import
 // --------------------------------------------------------------------------------
 
-import ruleTester from '../core/rule-tester.js';
+import ruleTester from '../tests/rule-tester.js';
 import rule from './no-irregular-dash.js';
 
 // --------------------------------------------------------------------------------

--- a/packages/eslint-markdown/src/rules/no-irregular-whitespace.test.js
+++ b/packages/eslint-markdown/src/rules/no-irregular-whitespace.test.js
@@ -7,7 +7,7 @@
 // Import
 // --------------------------------------------------------------------------------
 
-import ruleTester from '../core/rule-tester.js';
+import ruleTester from '../tests/rule-tester.js';
 import rule from './no-irregular-whitespace.js';
 
 // --------------------------------------------------------------------------------

--- a/packages/eslint-markdown/src/rules/no-tab.test.js
+++ b/packages/eslint-markdown/src/rules/no-tab.test.js
@@ -7,7 +7,7 @@
 // Import
 // --------------------------------------------------------------------------------
 
-import ruleTester from '../core/rule-tester.js';
+import ruleTester from '../tests/rule-tester.js';
 import rule from './no-tab.js';
 
 // --------------------------------------------------------------------------------

--- a/packages/eslint-markdown/src/rules/no-url-trailing-slash.test.js
+++ b/packages/eslint-markdown/src/rules/no-url-trailing-slash.test.js
@@ -7,7 +7,7 @@
 // Import
 // --------------------------------------------------------------------------------
 
-import ruleTester from '../core/rule-tester.js';
+import ruleTester from '../tests/rule-tester.js';
 import rule from './no-url-trailing-slash.js';
 
 // --------------------------------------------------------------------------------

--- a/packages/eslint-markdown/src/rules/require-image-title.test.js
+++ b/packages/eslint-markdown/src/rules/require-image-title.test.js
@@ -7,7 +7,7 @@
 // Import
 // --------------------------------------------------------------------------------
 
-import ruleTester from '../core/rule-tester.js';
+import ruleTester from '../tests/rule-tester.js';
 import rule from './require-image-title.js';
 
 // --------------------------------------------------------------------------------

--- a/packages/eslint-markdown/src/rules/require-link-title.test.js
+++ b/packages/eslint-markdown/src/rules/require-link-title.test.js
@@ -7,7 +7,7 @@
 // Import
 // --------------------------------------------------------------------------------
 
-import ruleTester from '../core/rule-tester.js';
+import ruleTester from '../tests/rule-tester.js';
 import rule from './require-link-title.js';
 
 // --------------------------------------------------------------------------------

--- a/packages/eslint-markdown/src/tests/rule-tester.js
+++ b/packages/eslint-markdown/src/tests/rule-tester.js
@@ -17,7 +17,7 @@ import markdown from '@eslint/markdown';
 
 /**
  * @import { MarkdownRuleDefinitionTypeOptions } from '@eslint/markdown';
- * @import { RuleModule } from './types.js';
+ * @import { RuleModule } from '../core/types.js';
  * @typedef {MarkdownRuleDefinitionTypeOptions['RuleOptions']} RuleOptions
  * @typedef {MarkdownRuleDefinitionTypeOptions['MessageIds']} MessageIds
  * @typedef {Parameters<RuleTester['run']>[2]} Tests

--- a/packages/eslint-markdown/tsconfig.json
+++ b/packages/eslint-markdown/tsconfig.json
@@ -10,11 +10,17 @@
     "src/**/*.cts",
     "src/**/*.tsx"
   ],
-  "exclude": ["src/**/*.test.js", "src/**/*.test.ts", "**/fixtures/**"],
+  "exclude": [
+    "src/**/*.test.js",
+    "src/**/*.test.ts",
+    "src/tests/**/*.js",
+    "src/tests/**/*.ts",
+    "**/fixtures/**"
+  ],
   "compilerOptions": {
     /* Modules */
     "rootDir": "./src",
-    "types": ["node", "mdast", "unist"],
+    "types": [],
 
     /* Emit */
     "outDir": "build",


### PR DESCRIPTION
This pull request refactors the test imports for all rule test files in the `eslint-markdown` package to improve the organization of test utilities. Specifically, it updates the import paths for the `ruleTester` utility and adjusts the npm package file to better exclude test and fixture files from the package.

Test import path refactoring:

* Changed all rule test files in `src/rules/` to import `ruleTester` from `../tests/rule-tester.js` instead of `../core/rule-tester.js`, standardizing test utility usage and improving maintainability. [[1]](diffhunk://#diff-7d9a7dd710de0ec5cb36da18aa87f9930eda18bbbacb87c907393ffc2a02ea38L10-R10) [[2]](diffhunk://#diff-0bd284b815ba15552336b174041a0a734b0ae8a2b8f05fac05d1f351ed7ebcdcL11-R11) [[3]](diffhunk://#diff-2cbfec7031da9954ea2e59d8fdce3d9a238fd96231bf56b585f3387e54dbb870L11-R11) [[4]](diffhunk://#diff-5328ab26d0139fb189bb66153e10014afdafec211c61130d137711ba46458addL10-R10) [[5]](diffhunk://#diff-d180be59aee3d4462e314f6f0469b3e9712edf410a77fa97c0bb7652376564c1L10-R10) [[6]](diffhunk://#diff-fd84e4c487d568fe4890155b516a6a1c85630113b0ba5d73005fe388273f75b6L10-R10) [[7]](diffhunk://#diff-53f1571be3774d5b9f76d3a65e72f44f4671324ae1aaaf23072fc412851c38b1L10-R10) [[8]](diffhunk://#diff-06210daf2ad5e78b3ba0e3b7c4d8adb5840ca1bc6e18f42a4e5e22e4e78e2db1L11-R11) [[9]](diffhunk://#diff-2eb1705208c69a5a3360160847f467d0fb85244e92ff68e891b293c641e28914L10-R10) [[10]](diffhunk://#diff-761ed27ac6cfbed3c5e56b5aead71cf7680db803b773cd8dafc1af5b01f3bba1L10-R10) [[11]](diffhunk://#diff-2549970a2d4f5efdbaa9fb03d73df9ae9e6381e779c10ab2d1ab53768e57ce7dL10-R10) [[12]](diffhunk://#diff-5069bb2528aad59dfcd6707950cee91a66be7781769948d6ed5dc003ac505a46L10-R10) [[13]](diffhunk://#diff-10fa0d09aed548aeb3cce158f97adac178aa801a566fbeb45c35c101459d438cL10-R10) [[14]](diffhunk://#diff-f97756642498b62d22e7eb5e7f7a5df081940b1f2c45e7c583d46306703fd078L10-R10) [[15]](diffhunk://#diff-4bd6b53a39060455483a02c95a9fca31d28f986bf16692b742debdb35e267ba3L10-R10) [[16]](diffhunk://#diff-c7bcc3207a287f396d41723c05e43289ae55617ffaa9fa0bfbb9d4711dd45053L10-R10) [[17]](diffhunk://#diff-eea321f29c333f4e6bdf68da6a7f9c7bea3e49e84b5659418f2003c2f46717a3L10-R10) [[18]](diffhunk://#diff-2f61f3d96d0cd3d480dd94213dca9344c42648f402c561a4839a7791dfab7d38L10-R10) [[19]](diffhunk://#diff-c70c80e4ede25e90f7c1b3a1cea0f04e5dfadfa85c99f65889993685c9ef8923L10-R10)

Package file updates:

* Updated `package.json` to exclude all files under `src/tests/` and `build/tests/` from the published package, in addition to existing fixture exclusions.