### PR TITLE
fix(eslint-markdown): mark package as side effect free

### DIFF
--- a/packages/eslint-markdown/package.json
+++ b/packages/eslint-markdown/package.json
@@ -2,6 +2,7 @@
   "name": "eslint-markdown",
   "version": "0.9.0",
   "type": "module",
+  "sideEffects": false,
   "description": "Lint your Markdown with ESLint.🛠️",
   "exports": {
     ".": {

--- a/packages/eslint-markdown/src/index.test.js
+++ b/packages/eslint-markdown/src/index.test.js
@@ -15,12 +15,19 @@ import { Linter } from 'eslint/universal';
 import markdown from '@eslint/markdown';
 
 import md from './index.js';
+import packageJson from '../package.json' with { type: 'json' };
 
 // --------------------------------------------------------------------------------
 // Test
 // --------------------------------------------------------------------------------
 
 describe('index', () => {
+  describe('package.json', () => {
+    it('should have `sideEffects: false`', () => {
+      strictEqual(packageJson.sideEffects, false);
+    });
+  });
+
   describe('Basic', () => {
     it('should have correct meta information', () => {
       strictEqual(md.meta.name, 'eslint-markdown');


### PR DESCRIPTION
This pull request introduces a small but important change to the `eslint-markdown` package: it marks the package as having no side effects, which can help with tree-shaking and bundling optimizations. Additionally, a test was added to ensure this property is set correctly in `package.json`.

- **Build and packaging improvements:**
  * Added `"sideEffects": false` to `package.json` to indicate the package has no side effects, improving bundler optimization.

- **Testing enhancements:**
  * Added a test in `index.test.js` to verify that `sideEffects` is set to `false` in `package.json`.