### PR TITLE
chore(release): bump package versions from `v0.9.0` to `v0.9.1` (`patch`)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "npm-eslint-markdown",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "npm-eslint-markdown",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "workspaces": [
         ".",
         "packages/*",
@@ -18,7 +18,7 @@
         "editorconfig-checker": "^6.1.1",
         "eslint": "^9.39.4",
         "eslint-config-bananass": "^0.6.1",
-        "eslint-markdown": "^0.9.0",
+        "eslint-markdown": "^0.9.1",
         "husky": "^9.1.7",
         "lint-staged": "^16.4.0",
         "markdownlint-cli": "^0.48.0",
@@ -10189,7 +10189,7 @@
       }
     },
     "packages/eslint-markdown": {
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "dependencies": {
         "@eslint/markdown": "^7.5.1",
@@ -10221,7 +10221,7 @@
         "@codecov/vite-plugin": "^2.0.1",
         "@shikijs/transformers": "^3.20.0",
         "@shikijs/vitepress-twoslash": "^3.20.0",
-        "eslint-markdown": "^0.9.0",
+        "eslint-markdown": "^0.9.1",
         "twoslash-eslint": "^0.3.4",
         "vitepress": "^2.0.0-alpha.15",
         "vitepress-plugin-group-icons": "^1.7.5"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "npm-eslint-markdown",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "type": "module",
   "packageManager": "npm@11.11.0",
   "engines": {
@@ -41,7 +41,7 @@
     "editorconfig-checker": "^6.1.1",
     "eslint": "^9.39.4",
     "eslint-config-bananass": "^0.6.1",
-    "eslint-markdown": "^0.9.0",
+    "eslint-markdown": "^0.9.1",
     "husky": "^9.1.7",
     "lint-staged": "^16.4.0",
     "markdownlint-cli": "^0.48.0",

--- a/packages/eslint-markdown/package.json
+++ b/packages/eslint-markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-markdown",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "type": "module",
   "sideEffects": false,
   "description": "Lint your Markdown with ESLint.🛠️",

--- a/website/package.json
+++ b/website/package.json
@@ -11,7 +11,7 @@
     "@codecov/vite-plugin": "^2.0.1",
     "@shikijs/transformers": "^3.20.0",
     "@shikijs/vitepress-twoslash": "^3.20.0",
-    "eslint-markdown": "^0.9.0",
+    "eslint-markdown": "^0.9.1",
     "twoslash-eslint": "^0.3.4",
     "vitepress": "^2.0.0-alpha.15",
     "vitepress-plugin-group-icons": "^1.7.5"


### PR DESCRIPTION
## Release Information: `v0.9.1`

New release of `lumirlumir/npm-eslint-markdown` has arrived! :tada:

This PR bumps the package versions from `v0.9.0` to `v0.9.1` (`patch`).

See [Actions](https://github.com/lumirlumir/npm-eslint-markdown/actions/runs/25994845369) for more details.

| Info        | Value                      |
| ----------- | -------------------------- |
| Repository  | `lumirlumir/npm-eslint-markdown` |
| SEMVER      | `patch`     |
| Pre ID      | `canary`      |
| Short SHA   | f37a38d       |
| Old Version | `v0.9.0`  |
| New Version | `v0.9.1`  |

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### :bug: Bug Fixes
* fix(eslint-markdown): exclude rule tester from package files by @lumirlumir in https://github.com/lumirlumir/npm-eslint-markdown/pull/573
* fix(eslint-markdown): mark package as side effect free by @lumirlumir in https://github.com/lumirlumir/npm-eslint-markdown/pull/574
### :memo: Documentation
* docs(*): update display-name references to `lumir` by @Copilot in https://github.com/lumirlumir/npm-eslint-markdown/pull/569
### :arrow_up: Dependency Updates
* chore(deps-dev): bump @types/node from 20.19.39 to 20.19.40 in the dev-dependencies group across 1 directory by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-markdown/pull/568
* chore(deps-dev): bump @types/node from 20.19.40 to 20.19.41 in the dev-dependencies group across 1 directory by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-markdown/pull/572


**Full Changelog**: https://github.com/lumirlumir/npm-eslint-markdown/compare/v0.9.0...v0.9.1