### PR TITLE
ci(*): add prefer-offline install flags and Node.js 26 test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           cache: npm # https://github.com/actions/setup-node#caching-global-packages-data
 
       - name: Install dependencies
-        run: npm ci --no-audit --no-fund
+        run: npm ci --no-audit --no-fund --prefer-offline
 
       - name: Build
         run: npm run build --if-present
@@ -57,7 +57,7 @@ jobs:
           cache: npm # https://github.com/actions/setup-node#caching-global-packages-data
 
       - name: Install dependencies
-        run: npm ci --no-audit --no-fund
+        run: npm ci --no-audit --no-fund --prefer-offline
 
       - name: Build
         run: npm run build --if-present

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
         run: npm install -g npm@latest
 
       - name: Install dependencies
-        run: npm ci --no-audit --no-fund
+        run: npm ci --no-audit --no-fund --prefer-offline
 
       - name: Build
         run: npm run build --if-present

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,10 +47,10 @@ jobs:
           cache: npm # https://github.com/actions/setup-node#caching-global-packages-data
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --no-audit --no-fund --prefer-offline
 
       - name: Install ESLint
-        run: npm install -D eslint@${{ matrix.eslint-version }} -w packages/eslint-markdown
+        run: npm install -D eslint@${{ matrix.eslint-version }} -w packages/eslint-markdown --no-audit --no-fund --prefer-offline
 
       - name: Build
         run: npm run build --if-present

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,7 @@ jobs:
           - ubuntu-latest
           - windows-latest
         node-version:
+          - 26.x
           - 24.x
           - 22.x
           - 22.13.0
@@ -50,7 +51,7 @@ jobs:
         run: npm ci --no-audit --no-fund --prefer-offline
 
       - name: Install ESLint
-        run: npm install --no-audit --no-fund --prefer-offline -D eslint@${{ matrix.eslint-version }} -w packages/eslint-markdown 
+        run: npm install --no-audit --no-fund --prefer-offline -D eslint@${{ matrix.eslint-version }} -w packages/eslint-markdown
 
       - name: Build
         run: npm run build --if-present

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
         run: npm ci --no-audit --no-fund --prefer-offline
 
       - name: Install ESLint
-        run: npm install -D eslint@${{ matrix.eslint-version }} -w packages/eslint-markdown --no-audit --no-fund --prefer-offline
+        run: npm install --no-audit --no-fund --prefer-offline -D eslint@${{ matrix.eslint-version }} -w packages/eslint-markdown 
 
       - name: Build
         run: npm run build --if-present

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
         run: npm ci --no-audit --no-fund --prefer-offline
 
       - name: Install ESLint
-        run: npm install -D eslint@${{ matrix.eslint-version }} -w packages/eslint-markdown
+        run: npm install --no-audit --no-fund -D eslint@${{ matrix.eslint-version }} -w packages/eslint-markdown
 
       - name: Build
         run: npm run build --if-present

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
         run: npm ci --no-audit --no-fund --prefer-offline
 
       - name: Install ESLint
-        run: npm install --no-audit --no-fund --prefer-offline -D eslint@${{ matrix.eslint-version }} -w packages/eslint-markdown
+        run: npm install -D eslint@${{ matrix.eslint-version }} -w packages/eslint-markdown
 
       - name: Build
         run: npm run build --if-present

--- a/.github/workflows/version-monorepo.yml
+++ b/.github/workflows/version-monorepo.yml
@@ -52,7 +52,7 @@ jobs:
           cache: npm # https://github.com/actions/setup-node#caching-global-packages-data
 
       - name: Install dependencies
-        run: npm ci --no-audit --no-fund
+        run: npm ci --no-audit --no-fund --prefer-offline
 
       - name: Set up environment variables
         run: |

--- a/scripts/version.js
+++ b/scripts/version.js
@@ -147,7 +147,7 @@ console.log(`
 ${bgCyan('Run `npm install` to update lockfile')}
 `);
 
-execSync('npm install --no-audit --no-fund --prefer-offline', { stdio: 'inherit' });
+execSync('npm install --no-audit --no-fund', { stdio: 'inherit' });
 
 console.log(`
 ${green('Successfully ran `npm install` to update lockfile')}

--- a/scripts/version.js
+++ b/scripts/version.js
@@ -147,7 +147,7 @@ console.log(`
 ${bgCyan('Run `npm install` to update lockfile')}
 `);
 
-execSync('npm install', { stdio: 'inherit' });
+execSync('npm install --no-audit --no-fund --prefer-offline', { stdio: 'inherit' });
 
 console.log(`
 ${green('Successfully ran `npm install` to update lockfile')}

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -3,6 +3,6 @@
   "cleanUrls": true,
   "framework": "vitepress",
   "ignoreCommand": "node ../scripts/vercel-ignore-command.js",
-  "installCommand": "npm install --prefix ..",
+  "installCommand": "npm install --no-audit --no-fund --prefer-offline --prefix ..",
   "outputDirectory": "build"
 }


### PR DESCRIPTION
## summary
- Add `--prefer-offline` to CI, publish, versioning, release-version, and Vercel install commands so npm can prefer cached package metadata/artifacts.
- Add the same install flags to the ESLint matrix install after a repo-wide scan found it was still missing.

## scope
- `.github/workflows/ci.yml`
- `.github/workflows/publish.yml`
- `.github/workflows/test.yml`
- `.github/workflows/version-monorepo.yml`
- `scripts/version.js`
- `website/vercel.json`

## validation
- Searched the repository for npm install commands and existing prefer-offline usage.
- Not run: `npm run test` per request.
- Not run: `npm run lint` per request.

## notes
- The commit hook ran automatically during commit and reported staged-file formatting/ESLint/editorconfig tasks completed.
- Left user-facing installation docs and `npm install -g npm@latest` unchanged intentionally.