### PR TITLE
chore(release): bump package versions from `v0.9.1` to `v0.10.0` (`minor`)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "npm-eslint-markdown",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "npm-eslint-markdown",
-      "version": "0.9.1",
+      "version": "0.10.0",
       "workspaces": [
         ".",
         "packages/*",
@@ -18,7 +18,7 @@
         "editorconfig-checker": "^6.1.1",
         "eslint": "^9.39.4",
         "eslint-config-bananass": "^0.7.0",
-        "eslint-markdown": "^0.9.1",
+        "eslint-markdown": "^0.10.0",
         "husky": "^9.1.7",
         "lint-staged": "^16.4.0",
         "markdownlint-cli": "^0.48.0",
@@ -10168,7 +10168,7 @@
       }
     },
     "packages/eslint-markdown": {
-      "version": "0.9.1",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
         "@eslint/markdown": "^7.5.1",
@@ -10200,7 +10200,7 @@
         "@codecov/vite-plugin": "^2.0.1",
         "@shikijs/transformers": "^3.20.0",
         "@shikijs/vitepress-twoslash": "^3.20.0",
-        "eslint-markdown": "^0.9.1",
+        "eslint-markdown": "^0.10.0",
         "twoslash-eslint": "^0.3.4",
         "vitepress": "^2.0.0-alpha.15",
         "vitepress-plugin-group-icons": "^1.7.5"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "npm-eslint-markdown",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "type": "module",
   "packageManager": "npm@10.9.2",
   "engines": {
@@ -53,7 +53,7 @@
     "editorconfig-checker": "^6.1.1",
     "eslint": "^9.39.4",
     "eslint-config-bananass": "^0.7.0",
-    "eslint-markdown": "^0.9.1",
+    "eslint-markdown": "^0.10.0",
     "husky": "^9.1.7",
     "lint-staged": "^16.4.0",
     "markdownlint-cli": "^0.48.0",

--- a/packages/eslint-markdown/package.json
+++ b/packages/eslint-markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-markdown",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "type": "module",
   "sideEffects": false,
   "description": "Lint your Markdown with ESLint. Additional rules for use with `@eslint/markdown`.🛠️",

--- a/website/package.json
+++ b/website/package.json
@@ -11,7 +11,7 @@
     "@codecov/vite-plugin": "^2.0.1",
     "@shikijs/transformers": "^3.20.0",
     "@shikijs/vitepress-twoslash": "^3.20.0",
-    "eslint-markdown": "^0.9.1",
+    "eslint-markdown": "^0.10.0",
     "twoslash-eslint": "^0.3.4",
     "vitepress": "^2.0.0-alpha.15",
     "vitepress-plugin-group-icons": "^1.7.5"


### PR DESCRIPTION
## Release Information: `v0.10.0`

New release of `lumirlumir/npm-eslint-markdown` has arrived! :tada:

This PR bumps the package versions from `v0.9.1` to `v0.10.0` (`minor`).

See [Actions](https://github.com/lumirlumir/npm-eslint-markdown/actions/runs/26888544533) for more details.

| Info        | Value                      |
| ----------- | -------------------------- |
| Repository  | `lumirlumir/npm-eslint-markdown` |
| SEMVER      | `minor`     |
| Pre ID      | `canary`      |
| Short SHA   | 6a13f8a       |
| Old Version | `v0.9.1`  |
| New Version | `v0.10.0`  |

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### :sparkles: Features
* feat(eslint-markdown): add suggestion for `no-control-character` by @lumirlumir in https://github.com/lumirlumir/npm-eslint-markdown/pull/583
* feat(eslint-markdown): create `require-heading-id` rule by @lumirlumir in https://github.com/lumirlumir/npm-eslint-markdown/pull/444
### :toolbox: Chores
* chore(sync-server): add `devEngines` field, update configs and CI by @lumirlumir in https://github.com/lumirlumir/npm-eslint-markdown/pull/579
### :arrows_counterclockwise: Continuous Integrations
* ci(*): add prefer-offline install flags and Node.js 26 test by @lumirlumir in https://github.com/lumirlumir/npm-eslint-markdown/pull/577
### :arrow_up: Dependency Updates
* chore(deps-dev): bump eslint-config-bananass from 0.6.1 to 0.7.0 in the dev-dependencies group across 1 directory by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-markdown/pull/582


**Full Changelog**: https://github.com/lumirlumir/npm-eslint-markdown/compare/v0.9.1...v0.10.0