### PR TITLE
chore(release): bump package versions from `v0.10.0` to `v0.11.0` (`minor`)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "npm-eslint-markdown",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "npm-eslint-markdown",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "workspaces": [
         ".",
         "packages/*",
@@ -18,7 +18,7 @@
         "editorconfig-checker": "^6.1.1",
         "eslint": "^9.39.4",
         "eslint-config-bananass": "^0.7.0",
-        "eslint-markdown": "^0.10.0",
+        "eslint-markdown": "^0.11.0",
         "husky": "^9.1.7",
         "lint-staged": "^16.4.0",
         "markdownlint-cli": "^0.48.0",
@@ -10656,7 +10656,7 @@
       }
     },
     "packages/eslint-markdown": {
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "@eslint/markdown": "^7.5.1",
@@ -10695,7 +10695,7 @@
         "@codecov/vite-plugin": "^2.0.1",
         "@shikijs/transformers": "^3.20.0",
         "@shikijs/vitepress-twoslash": "^3.20.0",
-        "eslint-markdown": "^0.10.0",
+        "eslint-markdown": "^0.11.0",
         "twoslash-eslint": "^0.3.4",
         "vitepress": "2.0.0-alpha.17",
         "vitepress-plugin-group-icons": "^1.7.5"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "npm-eslint-markdown",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "type": "module",
   "packageManager": "npm@10.9.2",
   "engines": {
@@ -53,7 +53,7 @@
     "editorconfig-checker": "^6.1.1",
     "eslint": "^9.39.4",
     "eslint-config-bananass": "^0.7.0",
-    "eslint-markdown": "^0.10.0",
+    "eslint-markdown": "^0.11.0",
     "husky": "^9.1.7",
     "lint-staged": "^16.4.0",
     "markdownlint-cli": "^0.48.0",

--- a/packages/eslint-markdown/package.json
+++ b/packages/eslint-markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-markdown",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "type": "module",
   "sideEffects": false,
   "description": "Lint your Markdown with ESLint. Additional rules for use with `@eslint/markdown`.🛠️",

--- a/website/package.json
+++ b/website/package.json
@@ -11,7 +11,7 @@
     "@codecov/vite-plugin": "^2.0.1",
     "@shikijs/transformers": "^3.20.0",
     "@shikijs/vitepress-twoslash": "^3.20.0",
-    "eslint-markdown": "^0.10.0",
+    "eslint-markdown": "^0.11.0",
     "twoslash-eslint": "^0.3.4",
     "vitepress": "2.0.0-alpha.17",
     "vitepress-plugin-group-icons": "^1.7.5"


### PR DESCRIPTION
## Release Information: `v0.11.0`

New release of `lumirlumir/npm-eslint-markdown` has arrived! :tada:

This PR bumps the package versions from `v0.10.0` to `v0.11.0` (`minor`).

See [Actions](https://github.com/lumirlumir/npm-eslint-markdown/actions/runs/27139396254) for more details.

| Info        | Value                      |
| ----------- | -------------------------- |
| Repository  | `lumirlumir/npm-eslint-markdown` |
| SEMVER      | `minor`     |
| Pre ID      | `canary`      |
| Short SHA   | 1b40dcb       |
| Old Version | `v0.10.0`  |
| New Version | `v0.11.0`  |

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### :boom: BREAKING CHANGES
* feat(eslint-markdown)!: add `no-consecutive-blank-line` rule by @lumirlumir in https://github.com/lumirlumir/npm-eslint-markdown/pull/587
### :memo: Documentation
* docs(*): update `vitepress` to latest by @lumirlumir in https://github.com/lumirlumir/npm-eslint-markdown/pull/585
### :arrow_up: Dependency Updates
* chore(deps): bump codecov/codecov-action from 6 to 7 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-markdown/pull/586


**Full Changelog**: https://github.com/lumirlumir/npm-eslint-markdown/compare/v0.10.0...v0.11.0