### PR TITLE
docs(website): update `migration.md` to include `MD001` from `markdownlint`

### DIFF
--- a/website/docs/get-started/migration.md
+++ b/website/docs/get-started/migration.md
@@ -40,6 +40,7 @@ This section is currently under construction and will be updated soon.
 
 | `markdownlint` | `eslint-markdown` or `@eslint/markdown` |
 | :------------- | :-------------------------------------- |
+| [`MD001` - Heading levels should only increment by one level at a time](https://github.com/DavidAnson/markdownlint/blob/main/doc/md001.md#md001---heading-levels-should-only-increment-by-one-level-at-a-time) :white_check_mark: | [`markdown/heading-increment`](https://github.com/eslint/markdown/blob/main/docs/rules/heading-increment.md#heading-increment) |
 | [`MD004` - Unordered list style](https://github.com/DavidAnson/markdownlint/blob/main/doc/md004.md#md004---unordered-list-style) :white_check_mark: | [`md/consistent-unordered-list-style`](../rules/consistent-unordered-list-style.md) |
 | [`MD010` - Hard tabs](https://github.com/DavidAnson/markdownlint/blob/main/doc/md010.md#md010---hard-tabs) :white_check_mark: | [`md/no-tab`](../rules/no-tab.md) |
 | [`MD012` - Multiple consecutive blank lines](https://github.com/DavidAnson/markdownlint/blob/main/doc/md012.md#md012---multiple-consecutive-blank-lines) :white_check_mark: | [`md/no-consecutive-blank-line`](../rules/no-consecutive-blank-line.md) |


### PR DESCRIPTION
This pull request adds a new rule mapping to the migration guide, helping users transition from `markdownlint` to equivalent ESLint rules.

Documentation update:

* Added a mapping for the `markdownlint` rule `MD001` ("Heading levels should only increment by one level at a time") to the corresponding ESLint rule `markdown/heading-increment` in the migration table in `website/docs/get-started/migration.md`.
