### PR TITLE
fix(eslint-markdown): preserve rule metadata literal types

### DIFF
--- a/packages/eslint-markdown/src/index.test-d.ts
+++ b/packages/eslint-markdown/src/index.test-d.ts
@@ -37,6 +37,16 @@ plugin.meta.version satisfies string;
 
 type RuleName = keyof typeof plugin.rules;
 
+({}) as (typeof plugin.rules)[RuleName]['meta']['type'] satisfies 'problem' | 'layout';
+({}) as (typeof plugin.rules)[RuleName]['meta']['docs']['description'] satisfies string;
+({}) as (typeof plugin.rules)[RuleName]['meta']['docs']['url'] satisfies string;
+({}) as (typeof plugin.rules)[RuleName]['meta']['docs']['recommended'] satisfies boolean;
+({}) as (typeof plugin.rules)[RuleName]['meta']['docs']['stylistic'] satisfies boolean;
+({}) as (typeof plugin.rules)[RuleName]['meta']['messages'] satisfies Record<
+  string,
+  string
+>;
+
 'allow-image-url' satisfies RuleName;
 'allow-link-url' satisfies RuleName;
 'code-lang-shorthand' satisfies RuleName;

--- a/packages/eslint-markdown/src/index.test-d.ts
+++ b/packages/eslint-markdown/src/index.test-d.ts
@@ -38,7 +38,7 @@ plugin.meta.version satisfies string;
 type RuleName = keyof typeof plugin.rules;
 
 ({}) as (typeof plugin.rules)[RuleName]['meta']['type'] satisfies 'problem' | 'layout';
-({}) as (typeof plugin.rules)[RuleName]['meta']['docs']['description'] satisfies string;
+({}) as (typeof plugin.rules)[RuleName]['meta']['docs']['description'] satisfies `${'Enforce' | 'Require' | 'Disallow'} ${string}`;
 ({}) as (typeof plugin.rules)[RuleName]['meta']['docs']['url'] satisfies string;
 ({}) as (typeof plugin.rules)[RuleName]['meta']['docs']['recommended'] satisfies boolean;
 ({}) as (typeof plugin.rules)[RuleName]['meta']['docs']['stylistic'] satisfies boolean;

--- a/packages/eslint-markdown/src/rules/allow-heading.ts
+++ b/packages/eslint-markdown/src/rules/allow-heading.ts
@@ -27,7 +27,7 @@ const headingRegex = /^#{1,6}\s+/u;
 // Rule Definition
 // --------------------------------------------------------------------------------
 
-const rule: RuleModule<RuleOptions, MessageIds> = {
+export default {
   meta: {
     type: 'problem',
 
@@ -186,6 +186,4 @@ const rule: RuleModule<RuleOptions, MessageIds> = {
       },
     };
   },
-};
-
-export default rule;
+} as const satisfies RuleModule<RuleOptions, MessageIds>;

--- a/packages/eslint-markdown/src/rules/allow-image-url.ts
+++ b/packages/eslint-markdown/src/rules/allow-image-url.ts
@@ -27,7 +27,7 @@ type MessageIds = 'allowImageUrl' | 'disallowImageUrl';
 // Rule Definition
 // --------------------------------------------------------------------------------
 
-const rule: RuleModule<RuleOptions, MessageIds> = {
+export default {
   meta: {
     type: 'problem',
 
@@ -184,6 +184,4 @@ const rule: RuleModule<RuleOptions, MessageIds> = {
       },
     };
   },
-};
-
-export default rule;
+} as const satisfies RuleModule<RuleOptions, MessageIds>;

--- a/packages/eslint-markdown/src/rules/allow-link-url.ts
+++ b/packages/eslint-markdown/src/rules/allow-link-url.ts
@@ -27,7 +27,7 @@ type MessageIds = 'allowLinkUrl' | 'disallowLinkUrl';
 // Rule Definition
 // --------------------------------------------------------------------------------
 
-const rule: RuleModule<RuleOptions, MessageIds> = {
+export default {
   meta: {
     type: 'problem',
 
@@ -184,6 +184,4 @@ const rule: RuleModule<RuleOptions, MessageIds> = {
       },
     };
   },
-};
-
-export default rule;
+} as const satisfies RuleModule<RuleOptions, MessageIds>;

--- a/packages/eslint-markdown/src/rules/code-lang-shorthand.ts
+++ b/packages/eslint-markdown/src/rules/code-lang-shorthand.ts
@@ -106,7 +106,7 @@ function normalize(str: string) {
 // Rule Definition
 // --------------------------------------------------------------------------------
 
-const rule: RuleModule<RuleOptions, MessageIds> = {
+export default {
   meta: {
     type: 'problem',
 
@@ -218,6 +218,4 @@ const rule: RuleModule<RuleOptions, MessageIds> = {
       },
     };
   },
-};
-
-export default rule;
+} as const satisfies RuleModule<RuleOptions, MessageIds>;

--- a/packages/eslint-markdown/src/rules/consistent-code-style.ts
+++ b/packages/eslint-markdown/src/rules/consistent-code-style.ts
@@ -58,7 +58,7 @@ function getCurrentCodeStyle(text: string): CodeStyle {
 // Rule Definition
 // --------------------------------------------------------------------------------
 
-const rule: RuleModule<RuleOptions, MessageIds> = {
+export default {
   meta: {
     type: 'layout',
 
@@ -259,6 +259,4 @@ const rule: RuleModule<RuleOptions, MessageIds> = {
       },
     };
   },
-};
-
-export default rule;
+} as const satisfies RuleModule<RuleOptions, MessageIds>;

--- a/packages/eslint-markdown/src/rules/consistent-delete-style.ts
+++ b/packages/eslint-markdown/src/rules/consistent-delete-style.ts
@@ -21,7 +21,7 @@ type MessageIds = 'style';
 // Rule Definition
 // --------------------------------------------------------------------------------
 
-const rule: RuleModule<RuleOptions, MessageIds> = {
+export default {
   meta: {
     type: 'layout',
 
@@ -111,6 +111,4 @@ const rule: RuleModule<RuleOptions, MessageIds> = {
       },
     };
   },
-};
-
-export default rule;
+} as const satisfies RuleModule<RuleOptions, MessageIds>;

--- a/packages/eslint-markdown/src/rules/consistent-emphasis-style.ts
+++ b/packages/eslint-markdown/src/rules/consistent-emphasis-style.ts
@@ -21,7 +21,7 @@ type MessageIds = 'style';
 // Rule Definition
 // --------------------------------------------------------------------------------
 
-const rule: RuleModule<RuleOptions, MessageIds> = {
+export default {
   meta: {
     type: 'layout',
 
@@ -111,6 +111,4 @@ const rule: RuleModule<RuleOptions, MessageIds> = {
       },
     };
   },
-};
-
-export default rule;
+} as const satisfies RuleModule<RuleOptions, MessageIds>;

--- a/packages/eslint-markdown/src/rules/consistent-inline-code-style.ts
+++ b/packages/eslint-markdown/src/rules/consistent-inline-code-style.ts
@@ -33,7 +33,7 @@ const trailingInlineCodeRegex =
 // Rule Definition
 // --------------------------------------------------------------------------------
 
-const rule: RuleModule<RuleOptions, MessageIds> = {
+export default {
   meta: {
     type: 'layout',
 
@@ -144,6 +144,4 @@ const rule: RuleModule<RuleOptions, MessageIds> = {
       },
     };
   },
-};
-
-export default rule;
+} as const satisfies RuleModule<RuleOptions, MessageIds>;

--- a/packages/eslint-markdown/src/rules/consistent-strong-style.ts
+++ b/packages/eslint-markdown/src/rules/consistent-strong-style.ts
@@ -21,7 +21,7 @@ type MessageIds = 'style';
 // Rule Definition
 // --------------------------------------------------------------------------------
 
-const rule: RuleModule<RuleOptions, MessageIds> = {
+export default {
   meta: {
     type: 'layout',
 
@@ -108,6 +108,4 @@ const rule: RuleModule<RuleOptions, MessageIds> = {
       },
     };
   },
-};
-
-export default rule;
+} as const satisfies RuleModule<RuleOptions, MessageIds>;

--- a/packages/eslint-markdown/src/rules/consistent-thematic-break-style.ts
+++ b/packages/eslint-markdown/src/rules/consistent-thematic-break-style.ts
@@ -21,7 +21,7 @@ type MessageIds = 'style';
 // Rule Definition
 // --------------------------------------------------------------------------------
 
-const rule: RuleModule<RuleOptions, MessageIds> = {
+export default {
   meta: {
     type: 'layout',
 
@@ -96,6 +96,4 @@ const rule: RuleModule<RuleOptions, MessageIds> = {
       },
     };
   },
-};
-
-export default rule;
+} as const satisfies RuleModule<RuleOptions, MessageIds>;

--- a/packages/eslint-markdown/src/rules/consistent-unordered-list-style.ts
+++ b/packages/eslint-markdown/src/rules/consistent-unordered-list-style.ts
@@ -45,7 +45,7 @@ function getNextUnorderedListStyle(
 // Rule Definition
 // --------------------------------------------------------------------------------
 
-const rule: RuleModule<RuleOptions, MessageIds> = {
+export default {
   meta: {
     type: 'layout',
 
@@ -151,6 +151,4 @@ const rule: RuleModule<RuleOptions, MessageIds> = {
       },
     };
   },
-};
-
-export default rule;
+} as const satisfies RuleModule<RuleOptions, MessageIds>;

--- a/packages/eslint-markdown/src/rules/en-capitalization.ts
+++ b/packages/eslint-markdown/src/rules/en-capitalization.ts
@@ -53,7 +53,7 @@ function findFirstLeafTextNode(node: any): Text | null {
 // Rule Definition
 // --------------------------------------------------------------------------------
 
-const rule: RuleModule<RuleOptions, MessageIds> = {
+export default {
   meta: {
     type: 'problem',
 
@@ -157,6 +157,4 @@ const rule: RuleModule<RuleOptions, MessageIds> = {
       },
     };
   },
-};
-
-export default rule;
+} as const satisfies RuleModule<RuleOptions, MessageIds>;

--- a/packages/eslint-markdown/src/rules/no-bold-paragraph.ts
+++ b/packages/eslint-markdown/src/rules/no-bold-paragraph.ts
@@ -24,7 +24,7 @@ type MessageIds = 'noBoldParagraph';
 // Rule Definition
 // --------------------------------------------------------------------------------
 
-const rule: RuleModule<RuleOptions, MessageIds> = {
+export default {
   meta: {
     type: 'problem',
 
@@ -67,6 +67,4 @@ const rule: RuleModule<RuleOptions, MessageIds> = {
       },
     };
   },
-};
-
-export default rule;
+} as const satisfies RuleModule<RuleOptions, MessageIds>;

--- a/packages/eslint-markdown/src/rules/no-consecutive-blank-line.ts
+++ b/packages/eslint-markdown/src/rules/no-consecutive-blank-line.ts
@@ -23,7 +23,7 @@ type MessageIds = 'noConsecutiveBlankLine';
 // Rule Definition
 // --------------------------------------------------------------------------------
 
-const rule: RuleModule<RuleOptions, MessageIds> = {
+export default {
   meta: {
     type: 'layout',
 
@@ -193,6 +193,4 @@ const rule: RuleModule<RuleOptions, MessageIds> = {
       },
     };
   },
-};
-
-export default rule;
+} as const satisfies RuleModule<RuleOptions, MessageIds>;

--- a/packages/eslint-markdown/src/rules/no-control-character.ts
+++ b/packages/eslint-markdown/src/rules/no-control-character.ts
@@ -31,7 +31,7 @@ const controlCharacterRegex = // eslint-disable-next-line no-control-regex -- Ne
 // Rule Definition
 // --------------------------------------------------------------------------------
 
-const rule: RuleModule<RuleOptions, MessageIds> = {
+export default {
   meta: {
     type: 'problem',
 
@@ -158,6 +158,4 @@ const rule: RuleModule<RuleOptions, MessageIds> = {
       },
     };
   },
-};
-
-export default rule;
+} as const satisfies RuleModule<RuleOptions, MessageIds>;

--- a/packages/eslint-markdown/src/rules/no-curly-quote.ts
+++ b/packages/eslint-markdown/src/rules/no-curly-quote.ts
@@ -39,7 +39,7 @@ const singleQuotationMark = "'";
 // Rule Definition
 // --------------------------------------------------------------------------------
 
-const rule: RuleModule<RuleOptions, MessageIds> = {
+export default {
   meta: {
     type: 'problem',
 
@@ -145,6 +145,4 @@ const rule: RuleModule<RuleOptions, MessageIds> = {
       },
     };
   },
-};
-
-export default rule;
+} as const satisfies RuleModule<RuleOptions, MessageIds>;

--- a/packages/eslint-markdown/src/rules/no-double-punctuation.ts
+++ b/packages/eslint-markdown/src/rules/no-double-punctuation.ts
@@ -32,7 +32,7 @@ const doublePunctuationRegex = /(?:^|(?<=[^!,.:;?]))[!,.:;?]{2}(?:$|(?=[^!,.:;?]
 // Rule Definition
 // --------------------------------------------------------------------------------
 
-const rule: RuleModule<RuleOptions, MessageIds> = {
+export default {
   meta: {
     type: 'problem',
 
@@ -166,6 +166,4 @@ const rule: RuleModule<RuleOptions, MessageIds> = {
       },
     };
   },
-};
-
-export default rule;
+} as const satisfies RuleModule<RuleOptions, MessageIds>;

--- a/packages/eslint-markdown/src/rules/no-double-space.ts
+++ b/packages/eslint-markdown/src/rules/no-double-space.ts
@@ -29,7 +29,7 @@ const singleSpace = ' ';
 // Rule Definition
 // --------------------------------------------------------------------------------
 
-const rule: RuleModule<RuleOptions, MessageIds> = {
+export default {
   meta: {
     type: 'problem',
 
@@ -105,6 +105,4 @@ const rule: RuleModule<RuleOptions, MessageIds> = {
       },
     };
   },
-};
-
-export default rule;
+} as const satisfies RuleModule<RuleOptions, MessageIds>;

--- a/packages/eslint-markdown/src/rules/no-emoji.ts
+++ b/packages/eslint-markdown/src/rules/no-emoji.ts
@@ -27,7 +27,7 @@ const emojiRegex = /\p{RGI_Emoji}/gv;
 // Rule Definition
 // --------------------------------------------------------------------------------
 
-const rule: RuleModule<RuleOptions, MessageIds> = {
+export default {
   meta: {
     type: 'problem',
 
@@ -98,6 +98,4 @@ const rule: RuleModule<RuleOptions, MessageIds> = {
       },
     };
   },
-};
-
-export default rule;
+} as const satisfies RuleModule<RuleOptions, MessageIds>;

--- a/packages/eslint-markdown/src/rules/no-git-conflict-marker.ts
+++ b/packages/eslint-markdown/src/rules/no-git-conflict-marker.ts
@@ -29,7 +29,7 @@ const gitConflictMarkerRegex =
 // Rule Definition
 // --------------------------------------------------------------------------------
 
-const rule: RuleModule<RuleOptions, MessageIds> = {
+export default {
   meta: {
     type: 'problem',
 
@@ -127,6 +127,4 @@ const rule: RuleModule<RuleOptions, MessageIds> = {
       },
     };
   },
-};
-
-export default rule;
+} as const satisfies RuleModule<RuleOptions, MessageIds>;

--- a/packages/eslint-markdown/src/rules/no-irregular-dash.ts
+++ b/packages/eslint-markdown/src/rules/no-irregular-dash.ts
@@ -31,7 +31,7 @@ const irregularDashRegex =
 // Rule Definition
 // --------------------------------------------------------------------------------
 
-const rule: RuleModule<RuleOptions, MessageIds> = {
+export default {
   meta: {
     type: 'problem',
 
@@ -139,6 +139,4 @@ const rule: RuleModule<RuleOptions, MessageIds> = {
       },
     };
   },
-};
-
-export default rule;
+} as const satisfies RuleModule<RuleOptions, MessageIds>;

--- a/packages/eslint-markdown/src/rules/no-irregular-whitespace.ts
+++ b/packages/eslint-markdown/src/rules/no-irregular-whitespace.ts
@@ -31,7 +31,7 @@ const irregularWhitespaceRegex =
 // Rule Definition
 // --------------------------------------------------------------------------------
 
-const rule: RuleModule<RuleOptions, MessageIds> = {
+export default {
   meta: {
     type: 'problem',
 
@@ -140,6 +140,4 @@ const rule: RuleModule<RuleOptions, MessageIds> = {
       },
     };
   },
-};
-
-export default rule;
+} as const satisfies RuleModule<RuleOptions, MessageIds>;

--- a/packages/eslint-markdown/src/rules/no-tab.ts
+++ b/packages/eslint-markdown/src/rules/no-tab.ts
@@ -30,7 +30,7 @@ const tabRegex = /\t/gu;
 // Rule Definition
 // --------------------------------------------------------------------------------
 
-const rule: RuleModule<RuleOptions, MessageIds> = {
+export default {
   meta: {
     type: 'problem',
 
@@ -138,6 +138,4 @@ const rule: RuleModule<RuleOptions, MessageIds> = {
       },
     };
   },
-};
-
-export default rule;
+} as const satisfies RuleModule<RuleOptions, MessageIds>;

--- a/packages/eslint-markdown/src/rules/no-url-trailing-slash.ts
+++ b/packages/eslint-markdown/src/rules/no-url-trailing-slash.ts
@@ -88,7 +88,7 @@ function hasTrailingSlash(url: string): boolean {
 // Rule Definition
 // --------------------------------------------------------------------------------
 
-const rule: RuleModule<RuleOptions, MessageIds> = {
+export default {
   meta: {
     type: 'problem',
 
@@ -163,6 +163,4 @@ const rule: RuleModule<RuleOptions, MessageIds> = {
       },
     };
   },
-};
-
-export default rule;
+} as const satisfies RuleModule<RuleOptions, MessageIds>;

--- a/packages/eslint-markdown/src/rules/require-heading-id.ts
+++ b/packages/eslint-markdown/src/rules/require-heading-id.ts
@@ -26,7 +26,7 @@ type MessageIds = 'headingIdAlways' | 'headingIdNever';
 // Rule Definition
 // --------------------------------------------------------------------------------
 
-const rule: RuleModule<RuleOptions, MessageIds> = {
+export default {
   meta: {
     type: 'problem',
 
@@ -236,6 +236,4 @@ const rule: RuleModule<RuleOptions, MessageIds> = {
       },
     };
   },
-};
-
-export default rule;
+} as const satisfies RuleModule<RuleOptions, MessageIds>;

--- a/packages/eslint-markdown/src/rules/require-image-title.ts
+++ b/packages/eslint-markdown/src/rules/require-image-title.ts
@@ -25,7 +25,7 @@ type MessageIds = 'requireImageTitle';
 // Rule Definition
 // --------------------------------------------------------------------------------
 
-const rule: RuleModule<RuleOptions, MessageIds> = {
+export default {
   meta: {
     type: 'problem',
 
@@ -137,6 +137,4 @@ const rule: RuleModule<RuleOptions, MessageIds> = {
       },
     };
   },
-};
-
-export default rule;
+} as const satisfies RuleModule<RuleOptions, MessageIds>;

--- a/packages/eslint-markdown/src/rules/require-link-title.ts
+++ b/packages/eslint-markdown/src/rules/require-link-title.ts
@@ -25,7 +25,7 @@ type MessageIds = 'requireLinkTitle';
 // Rule Definition
 // --------------------------------------------------------------------------------
 
-const rule: RuleModule<RuleOptions, MessageIds> = {
+export default {
   meta: {
     type: 'problem',
 
@@ -142,6 +142,4 @@ const rule: RuleModule<RuleOptions, MessageIds> = {
       },
     };
   },
-};
-
-export default rule;
+} as const satisfies RuleModule<RuleOptions, MessageIds>;


### PR DESCRIPTION
This pull request refactors all rule modules in the `eslint-markdown` package to use a modern TypeScript pattern for type safety and export consistency. Instead of assigning rule objects to a `rule` variable and exporting them at the end of each file, the rule objects are now exported directly as default exports and asserted to satisfy their respective `RuleModule` types. Additionally, type-level tests are added to ensure rule metadata conforms to expected types.

The most important changes are:

### Rule module export modernization

* All rule files in `packages/eslint-markdown/src/rules/` now directly export their rule objects as the default export, using the `as const satisfies RuleModule<...>` pattern for improved type safety and clarity. This removes the intermediate `rule` variable and ensures better type inference. [[1]](diffhunk://#diff-f0c45d42ca398155c9a8668f98a6f2403e937f915f61bad1dc4582aa2714996bL30-R30) [[2]](diffhunk://#diff-f0c45d42ca398155c9a8668f98a6f2403e937f915f61bad1dc4582aa2714996bL187-R187) [[3]](diffhunk://#diff-c2020f9d6c66e84127343f5ad0efdf7aa23d0f6a81fe52bfe8c738ab37a7bc64L30-R30) [[4]](diffhunk://#diff-c2020f9d6c66e84127343f5ad0efdf7aa23d0f6a81fe52bfe8c738ab37a7bc64L187-R187) [[5]](diffhunk://#diff-2f67cc1c99c395d7aab528f441d7552070a7634394d73160c10a49b9323e09f0L109-R109) [[6]](diffhunk://#diff-2f67cc1c99c395d7aab528f441d7552070a7634394d73160c10a49b9323e09f0L221-R221) [[7]](diffhunk://#diff-e380bccdfd4e25f014998236ed7d4ce0ed8c83a2a73bc1a3b6e91f36b6b064f6L61-R61) [[8]](diffhunk://#diff-e380bccdfd4e25f014998236ed7d4ce0ed8c83a2a73bc1a3b6e91f36b6b064f6L262-R262) [[9]](diffhunk://#diff-122e7df05096f90e6751f337a3af771a9f9713e0ae5baa3a49720435892b928cL24-R24) [[10]](diffhunk://#diff-122e7df05096f90e6751f337a3af771a9f9713e0ae5baa3a49720435892b928cL114-R114) [[11]](diffhunk://#diff-465b21ce4803b884b1d14490d1b609ac70e92e09a29237386cb5602a553559c4L24-R24) [[12]](diffhunk://#diff-465b21ce4803b884b1d14490d1b609ac70e92e09a29237386cb5602a553559c4L114-R114) [[13]](diffhunk://#diff-1f98370b34f8aeb560497cc1c0f388f4bb0678973460071ab4ac2f752cbd7841L36-R36) [[14]](diffhunk://#diff-1f98370b34f8aeb560497cc1c0f388f4bb0678973460071ab4ac2f752cbd7841L147-R147) [[15]](diffhunk://#diff-3e8a02998be95259316e2b512c950f6a4c1886f66af7c14a09a784fbb456437bL24-R24) [[16]](diffhunk://#diff-3e8a02998be95259316e2b512c950f6a4c1886f66af7c14a09a784fbb456437bL111-R111) [[17]](diffhunk://#diff-a3a3af13af75c816fd5df7d75d8556eaf39313d1e682f4a4a23461abdbf6d2dfL24-R24) [[18]](diffhunk://#diff-a3a3af13af75c816fd5df7d75d8556eaf39313d1e682f4a4a23461abdbf6d2dfL99-R99) [[19]](diffhunk://#diff-73d0a359015d9b8bb06394493c2ec12a49e75bb871c380499311fd2904a3f0acL48-R48) [[20]](diffhunk://#diff-73d0a359015d9b8bb06394493c2ec12a49e75bb871c380499311fd2904a3f0acL154-R154) [[21]](diffhunk://#diff-d0ff5c60359653cea1eda5c867580eabc00a03889dabbd78905d5d6ceb281cd3L56-R56) [[22]](diffhunk://#diff-d0ff5c60359653cea1eda5c867580eabc00a03889dabbd78905d5d6ceb281cd3L160-R160) [[23]](diffhunk://#diff-c08e8588bed93da6a6cef61128a1a7140320ff6cc15a14029e3644d8cfed062aL27-R27) [[24]](diffhunk://#diff-c08e8588bed93da6a6cef61128a1a7140320ff6cc15a14029e3644d8cfed062aL70-R70) [[25]](diffhunk://#diff-437da1d88c3e2eeb829b3c663dc6a1768fd5cc68d1934d958886a1028cc9db3cL26-R26) [[26]](diffhunk://#diff-437da1d88c3e2eeb829b3c663dc6a1768fd5cc68d1934d958886a1028cc9db3cL196-R196) [[27]](diffhunk://#diff-237c7e3ad6072c343cd4c7f20bef3efc863cf330417119a11397663e0f45724fL34-R34) [[28]](diffhunk://#diff-237c7e3ad6072c343cd4c7f20bef3efc863cf330417119a11397663e0f45724fL161-R161) [[29]](diffhunk://#diff-b8b27e6f51ac0c1ce5ab9af387a0c87503e07d96490642633afbfb88e97ab2d4L42-R42) [[30]](diffhunk://#diff-b8b27e6f51ac0c1ce5ab9af387a0c87503e07d96490642633afbfb88e97ab2d4L148-R148) [[31]](diffhunk://#diff-ae55d05e7c659eb90dac6e130409d6e4eee25f71971c8c999888d37bf4e4e839L35-R35) [[32]](diffhunk://#diff-ae55d05e7c659eb90dac6e130409d6e4eee25f71971c8c999888d37bf4e4e839L169-R169) [[33]](diffhunk://#diff-6cca6805564b5f9ce65c30b093e9954036a2d2c86b126e73edb840ef5b2a7516L32-R32) [[34]](diffhunk://#diff-6cca6805564b5f9ce65c30b093e9954036a2d2c86b126e73edb840ef5b2a7516L108-R108) [[35]](diffhunk://#diff-28aa1df3950b00bc0290418ee776d141b306e682d657432b4db33bda3e6dc0c4L30-R30) [[36]](diffhunk://#diff-28aa1df3950b00bc0290418ee776d141b306e682d657432b4db33bda3e6dc0c4L101-R101) [[37]](diffhunk://#diff-fc8d30713d952bffeccd5e938b332f60474d26167270c16b9f511cda7f369087L30-R30) [[38]](diffhunk://#diff-fc8d30713d952bffeccd5e938b332f60474d26167270c16b9f511cda7f369087L189-R189)

### Type-level testing improvements

* The test file `packages/eslint-markdown/src/index.test-d.ts` now includes assertions that each rule's metadata fields (`type`, `docs.description`, `docs.url`, `docs.recommended`, `docs.stylistic`, and `messages`) conform to the expected types, increasing type safety and maintainability.

These changes modernize the codebase, improve type safety, and make the rule modules easier to maintain and reason about.