### PR TITLE
chore(release): bump package versions from `v0.11.0` to `v0.11.1` (`patch`)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "npm-eslint-markdown",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "npm-eslint-markdown",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "workspaces": [
         "packages/*",
         "website"
@@ -10542,7 +10542,7 @@
       }
     },
     "packages/eslint-markdown": {
-      "version": "0.11.0",
+      "version": "0.11.1",
       "license": "MIT",
       "dependencies": {
         "@eslint/markdown": "^7.5.1",
@@ -10582,7 +10582,7 @@
         "@codecov/vite-plugin": "^2.0.1",
         "@shikijs/transformers": "^3.20.0",
         "@shikijs/vitepress-twoslash": "^3.20.0",
-        "eslint-markdown": "^0.11.0",
+        "eslint-markdown": "^0.11.1",
         "twoslash-eslint": "^0.3.4",
         "vitepress": "2.0.0-alpha.17",
         "vitepress-plugin-group-icons": "^1.7.5"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "npm-eslint-markdown",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "type": "module",
   "packageManager": "npm@10.9.2",
   "engines": {

--- a/packages/eslint-markdown/package.json
+++ b/packages/eslint-markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-markdown",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "type": "module",
   "sideEffects": false,
   "description": "Lint your Markdown with ESLint. Additional rules for use with `@eslint/markdown`.🛠️",

--- a/website/package.json
+++ b/website/package.json
@@ -11,7 +11,7 @@
     "@codecov/vite-plugin": "^2.0.1",
     "@shikijs/transformers": "^3.20.0",
     "@shikijs/vitepress-twoslash": "^3.20.0",
-    "eslint-markdown": "^0.11.0",
+    "eslint-markdown": "^0.11.1",
     "twoslash-eslint": "^0.3.4",
     "vitepress": "2.0.0-alpha.17",
     "vitepress-plugin-group-icons": "^1.7.5"


### PR DESCRIPTION
## Release Information: `v0.11.1`

New release of `lumirlumir/npm-eslint-markdown` has arrived! :tada:

This PR bumps the package versions from `v0.11.0` to `v0.11.1` (`patch`).

See [Actions](https://github.com/lumirlumir/npm-eslint-markdown/actions/runs/28520611281) for more details.

| Info        | Value                      |
| ----------- | -------------------------- |
| Repository  | `lumirlumir/npm-eslint-markdown` |
| SEMVER      | `patch`     |
| Pre ID      | `canary`      |
| Short SHA   | 6dc21af       |
| Old Version | `v0.11.0`  |
| New Version | `v0.11.1`  |

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### :bug: Bug Fixes
* fix(eslint-markdown): preserve rule metadata literal types by @lumirlumir in https://github.com/lumirlumir/npm-eslint-markdown/pull/605
### :hammer_and_wrench: Builds
* build(*): add TypeScript project references by @lumirlumir in https://github.com/lumirlumir/npm-eslint-markdown/pull/598
### :toolbox: Chores
* chore(sync-server): update `actions/checkout` and `.nvmrc` by @lumirlumir in https://github.com/lumirlumir/npm-eslint-markdown/pull/596
* chore(*): migrate to `vitest` by @lumirlumir in https://github.com/lumirlumir/npm-eslint-markdown/pull/597
### :recycle: Code Refactoring
* refactor(eslint-markdown): migrate to typescript by @lumirlumir in https://github.com/lumirlumir/npm-eslint-markdown/pull/599
### :arrow_up: Dependency Updates
* chore(deps-dev): bump prettier from 3.8.3 to 3.8.4 in the dev-dependencies group across 1 directory by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-markdown/pull/589
* chore(deps-dev): bump @types/node from 20.19.42 to 20.19.43 in the dev-dependencies group across 1 directory by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-markdown/pull/590
* chore(deps-dev): bump undici from 6.26.0 to 6.27.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-markdown/pull/595
* chore(deps): bump actions/checkout from 6 to 7 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-markdown/pull/594
* chore(deps-dev): bump prettier from 3.8.4 to 3.9.1 in the dev-dependencies group across 1 directory by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-markdown/pull/600
* chore(deps-dev): bump prettier from 3.9.1 to 3.9.4 in the dev-dependencies group across 1 directory by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-markdown/pull/602


**Full Changelog**: https://github.com/lumirlumir/npm-eslint-markdown/compare/v0.11.0...v0.11.1