### PR TITLE
feat(eslint-markdown): add `allow-heading` rule

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -53,23 +53,16 @@ export default defineConfig([
     name: 'md/website/rules',
     files: ['website/docs/rules/**/*.md'],
     rules: {
-      /* TODO: Turn this back on when `allow-heading` rule is stabilized.
       'md/allow-heading': [
         'error',
         {
-          h2: [
-            'Rule Details',
-            'Examples',
-            'Options',
-            'Fix',
-            'Limitations',
-            'When Not To Use It',
-            'Further Reading',
-            'Prior Art',
-          ],
+          h2: {
+            allow: [
+              /^## (?:Rule Details|Examples|Options|Fix|Suggestion|Limitations|When Not To Use It|Further Reading|Prior Art)$/u,
+            ],
+          },
         },
       ],
-      */
     },
   },
 ]);

--- a/packages/eslint-markdown/src/configs/all.ts
+++ b/packages/eslint-markdown/src/configs/all.ts
@@ -29,6 +29,7 @@ export default function all(plugin: ESLint.Plugin) {
     },
     language: 'markdown/gfm',
     rules: {
+      'md/allow-heading': 'error',
       'md/allow-image-url': 'error',
       'md/allow-link-url': 'error',
       'md/code-lang-shorthand': 'error',

--- a/packages/eslint-markdown/src/rules/allow-heading.test.ts
+++ b/packages/eslint-markdown/src/rules/allow-heading.test.ts
@@ -180,6 +180,26 @@ Multiple Lines
         },
       ],
     },
+
+    // Edge cases
+    {
+      name: 'ATX: Headings should not be reported with global allow pattern',
+      code: '# Hello\n# Hello',
+      options: [
+        {
+          h1: { allow: [/^# Hello$/g] },
+        },
+      ],
+    },
+    {
+      name: 'ATX: Headings should not be reported with sticky allow pattern',
+      code: '# Hello\n# Hello',
+      options: [
+        {
+          h1: { allow: [/^# Hello$/y] },
+        },
+      ],
+    },
   ],
 
   invalid: [
@@ -636,6 +656,60 @@ Multiple Lines
           endLine: 2,
           endColumn: 9,
           data: { depth: '2', heading: '## World', allow: '' },
+        },
+      ],
+    },
+    {
+      name: 'ATX: Headings should be reported with global disallow pattern',
+      code: '# Hello\n# Hello',
+      options: [
+        {
+          h1: { disallow: [/^# Hello$/g] },
+        },
+      ],
+      errors: [
+        {
+          messageId: 'disallowHeading',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 8,
+          data: { depth: '1', heading: '# Hello', disallow: '`/^# Hello$/g`' },
+        },
+        {
+          messageId: 'disallowHeading',
+          line: 2,
+          column: 1,
+          endLine: 2,
+          endColumn: 8,
+          data: { depth: '1', heading: '# Hello', disallow: '`/^# Hello$/g`' },
+        },
+      ],
+    },
+    {
+      name: 'ATX: Headings should be reported with sticky disallow pattern',
+      code: '# Hello\n# Hello',
+      options: [
+        {
+          h1: { disallow: [/^# Hello$/y] },
+        },
+      ],
+      errors: [
+        {
+          messageId: 'disallowHeading',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 8,
+          data: { depth: '1', heading: '# Hello', disallow: '`/^# Hello$/y`' },
+        },
+        {
+          messageId: 'disallowHeading',
+          line: 2,
+          column: 1,
+          endLine: 2,
+          endColumn: 8,
+          data: { depth: '1', heading: '# Hello', disallow: '`/^# Hello$/y`' },
         },
       ],
     },

--- a/packages/eslint-markdown/src/rules/allow-heading.test.ts
+++ b/packages/eslint-markdown/src/rules/allow-heading.test.ts
@@ -26,7 +26,7 @@ ruleTester('allow-heading', rule, {
       code: '  ',
     },
     {
-      name: 'Headings should not be reported by default',
+      name: 'ATX: Headings should not be reported by default',
       code: `
 # Heading 1
 ## Heading 2
@@ -36,10 +36,39 @@ ruleTester('allow-heading', rule, {
 ###### Heading 6
 `,
     },
+    {
+      name: 'ATX Closed: Headings should not be reported by default',
+      code: `
+# Heading 1 #
+## Heading 2 ##
+### Heading 3 ###
+#### Heading 4 ####
+##### Heading 5 #####
+###### Heading 6 ######
+`,
+    },
+    {
+      name: 'Setext: Headings should not be reported by default',
+      code: `
+Heading 1
+=========
+
+Heading 1
+Multiple Lines
+=========
+
+Heading 2
+---------
+
+Heading 2
+Multiple Lines
+---------
+`,
+    },
 
     // Options
     {
-      name: 'Headings should not be reported when they are allowed',
+      name: 'ATX: Headings should not be reported when they are allowed',
       code: `
 # Hello
 # World
@@ -71,7 +100,63 @@ ruleTester('allow-heading', rule, {
       ],
     },
     {
-      name: 'Headings should not be reported when they are not disallowed',
+      name: 'ATX Closed: Headings should not be reported when they are allowed',
+      code: `
+# Hello #
+# World #
+
+## Hello ##
+## World ##
+
+### Hello ###
+### World ###
+
+#### Hello ####
+#### World ####
+
+##### Hello #####
+##### World #####
+
+###### Hello ######
+###### World ######
+`,
+      options: [
+        {
+          h1: { allow: [/^# (?:Hello|World) #$/u] },
+          h2: { allow: [/^## (?:Hello|World) ##$/u] },
+          h3: { allow: [/^### (?:Hello|World) ###$/u] },
+          h4: { allow: [/^#### (?:Hello|World) ####$/u] },
+          h5: { allow: [/^##### (?:Hello|World) #####$/u] },
+          h6: { allow: [/^###### (?:Hello|World) ######$/u] },
+        },
+      ],
+    },
+    {
+      name: 'Setext: Headings should not be reported when they are allowed',
+      code: `
+Hello
+=====
+
+Hello
+Multiple Lines
+=====
+
+World
+-----
+
+World
+Multiple Lines
+-----
+`,
+      options: [
+        {
+          h1: { allow: [/^Hello(?:\nMultiple Lines)?\n=+$/u] },
+          h2: { allow: [/^World(?:\nMultiple Lines)?\n-+$/u] },
+        },
+      ],
+    },
+    {
+      name: 'ATX: Headings should not be reported when they are not disallowed',
       code: `
 # Hello
 ## World
@@ -84,7 +169,7 @@ ruleTester('allow-heading', rule, {
       ],
     },
     {
-      name: 'Headings should not be reported when they are allowed and not disallowed',
+      name: 'ATX: Headings should not be reported when they are allowed and not disallowed',
       code: '# Hello',
       options: [
         {
@@ -100,7 +185,7 @@ ruleTester('allow-heading', rule, {
   invalid: [
     // Basic: allow heading
     {
-      name: 'ATX: h1 heading should be reported when it is not allowed',
+      name: 'ATX: H1 heading should be reported when it is not allowed',
       code: '# Hello',
       options: [
         {
@@ -119,7 +204,7 @@ ruleTester('allow-heading', rule, {
       ],
     },
     {
-      name: 'ATX: h2 heading should be reported when it is not allowed',
+      name: 'ATX: H2 heading should be reported when it is not allowed',
       code: '## Hello',
       options: [
         {
@@ -138,7 +223,7 @@ ruleTester('allow-heading', rule, {
       ],
     },
     {
-      name: 'ATX: h3 heading should be reported when it is not allowed',
+      name: 'ATX: H3 heading should be reported when it is not allowed',
       code: '### Hello',
       options: [
         {
@@ -157,7 +242,7 @@ ruleTester('allow-heading', rule, {
       ],
     },
     {
-      name: 'ATX: h4 heading should be reported when it is not allowed',
+      name: 'ATX: H4 heading should be reported when it is not allowed',
       code: '#### Hello',
       options: [
         {
@@ -176,7 +261,7 @@ ruleTester('allow-heading', rule, {
       ],
     },
     {
-      name: 'ATX: h5 heading should be reported when it is not allowed',
+      name: 'ATX: H5 heading should be reported when it is not allowed',
       code: '##### Hello',
       options: [
         {
@@ -195,7 +280,7 @@ ruleTester('allow-heading', rule, {
       ],
     },
     {
-      name: 'ATX: h6 heading should be reported when it is not allowed',
+      name: 'ATX: H6 heading should be reported when it is not allowed',
       code: '###### Hello',
       options: [
         {
@@ -214,9 +299,229 @@ ruleTester('allow-heading', rule, {
       ],
     },
 
+    {
+      name: 'ATX Closed: H1 heading should be reported when it is not allowed',
+      code: '# Hello #',
+      options: [
+        {
+          h1: { allow: [/^# World #$/u] },
+        },
+      ],
+      errors: [
+        {
+          messageId: 'allowHeading',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 10,
+          data: { depth: '1', heading: '# Hello #', allow: '`/^# World #$/u`' },
+        },
+      ],
+    },
+    {
+      name: 'ATX Closed: H2 heading should be reported when it is not allowed',
+      code: '## Hello ##',
+      options: [
+        {
+          h2: { allow: [/^## World ##$/u] },
+        },
+      ],
+      errors: [
+        {
+          messageId: 'allowHeading',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 12,
+          data: { depth: '2', heading: '## Hello ##', allow: '`/^## World ##$/u`' },
+        },
+      ],
+    },
+    {
+      name: 'ATX Closed: H3 heading should be reported when it is not allowed',
+      code: '### Hello ###',
+      options: [
+        {
+          h3: { allow: [/^### World ###$/u] },
+        },
+      ],
+      errors: [
+        {
+          messageId: 'allowHeading',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 14,
+          data: { depth: '3', heading: '### Hello ###', allow: '`/^### World ###$/u`' },
+        },
+      ],
+    },
+    {
+      name: 'ATX Closed: H4 heading should be reported when it is not allowed',
+      code: '#### Hello ####',
+      options: [
+        {
+          h4: { allow: [/^#### World ####$/u] },
+        },
+      ],
+      errors: [
+        {
+          messageId: 'allowHeading',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 16,
+          data: {
+            depth: '4',
+            heading: '#### Hello ####',
+            allow: '`/^#### World ####$/u`',
+          },
+        },
+      ],
+    },
+    {
+      name: 'ATX Closed: H5 heading should be reported when it is not allowed',
+      code: '##### Hello #####',
+      options: [
+        {
+          h5: { allow: [/^##### World #####$/u] },
+        },
+      ],
+      errors: [
+        {
+          messageId: 'allowHeading',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 18,
+          data: {
+            depth: '5',
+            heading: '##### Hello #####',
+            allow: '`/^##### World #####$/u`',
+          },
+        },
+      ],
+    },
+    {
+      name: 'ATX Closed: H6 heading should be reported when it is not allowed',
+      code: '###### Hello ######',
+      options: [
+        {
+          h6: { allow: [/^###### World ######$/u] },
+        },
+      ],
+      errors: [
+        {
+          messageId: 'allowHeading',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 20,
+          data: {
+            depth: '6',
+            heading: '###### Hello ######',
+            allow: '`/^###### World ######$/u`',
+          },
+        },
+      ],
+    },
+
+    {
+      name: 'Setext: H1 heading should be reported when it is not allowed',
+      code: 'Heading 1\n=========',
+      options: [
+        {
+          h1: { allow: [/^World\n=+$/u] },
+        },
+      ],
+      errors: [
+        {
+          messageId: 'allowHeading',
+          line: 1,
+          column: 1,
+          endLine: 2,
+          endColumn: 10,
+          data: {
+            depth: '1',
+            heading: 'Heading 1\n=========',
+            allow: '`/^World\\n=+$/u`',
+          },
+        },
+      ],
+    },
+    {
+      name: 'Setext: Multiline h1 heading should be reported when it is not allowed',
+      code: 'Heading 1\nMultiple Lines\n=========',
+      options: [
+        {
+          h1: { allow: [/^World\nMultiple Lines\n=+$/u] },
+        },
+      ],
+      errors: [
+        {
+          messageId: 'allowHeading',
+          line: 1,
+          column: 1,
+          endLine: 3,
+          endColumn: 10,
+          data: {
+            depth: '1',
+            heading: 'Heading 1\nMultiple Lines\n=========',
+            allow: '`/^World\\nMultiple Lines\\n=+$/u`',
+          },
+        },
+      ],
+    },
+    {
+      name: 'Setext: H2 heading should be reported when it is not allowed',
+      code: 'Heading 2\n---------',
+      options: [
+        {
+          h2: { allow: [/^World\n-+$/u] },
+        },
+      ],
+      errors: [
+        {
+          messageId: 'allowHeading',
+          line: 1,
+          column: 1,
+          endLine: 2,
+          endColumn: 10,
+          data: {
+            depth: '2',
+            heading: 'Heading 2\n---------',
+            allow: '`/^World\\n-+$/u`',
+          },
+        },
+      ],
+    },
+    {
+      name: 'Setext: Multiline h2 heading should be reported when it is not allowed',
+      code: 'Heading 2\nMultiple Lines\n---------',
+      options: [
+        {
+          h2: { allow: [/^World\nMultiple Lines\n-+$/u] },
+        },
+      ],
+      errors: [
+        {
+          messageId: 'allowHeading',
+          line: 1,
+          column: 1,
+          endLine: 3,
+          endColumn: 10,
+          data: {
+            depth: '2',
+            heading: 'Heading 2\nMultiple Lines\n---------',
+            allow: '`/^World\\nMultiple Lines\\n-+$/u`',
+          },
+        },
+      ],
+    },
+
     // Basic: disallow heading
     {
-      name: 'Heading should be reported when it is disallowed',
+      name: 'ATX: Heading should be reported when it is disallowed',
       code: '# Hello',
       options: [
         {
@@ -231,6 +536,44 @@ ruleTester('allow-heading', rule, {
           endLine: 1,
           endColumn: 8,
           data: { depth: '1', heading: '# Hello', disallow: '`/^# Hello$/u`' },
+        },
+      ],
+    },
+    {
+      name: 'ATX Closed: Heading should be reported when it is disallowed',
+      code: '# Hello #',
+      options: [
+        {
+          h1: { disallow: [/^# Hello #$/u] },
+        },
+      ],
+      errors: [
+        {
+          messageId: 'disallowHeading',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 10,
+          data: { depth: '1', heading: '# Hello #', disallow: '`/^# Hello #$/u`' },
+        },
+      ],
+    },
+    {
+      name: 'Setext: Heading should be reported when it is disallowed',
+      code: 'Hello\n=====',
+      options: [
+        {
+          h1: { disallow: [/^Hello\n=+$/u] },
+        },
+      ],
+      errors: [
+        {
+          messageId: 'disallowHeading',
+          line: 1,
+          column: 1,
+          endLine: 2,
+          endColumn: 6,
+          data: { depth: '1', heading: 'Hello\n=====', disallow: '`/^Hello\\n=+$/u`' },
         },
       ],
     },

--- a/packages/eslint-markdown/src/rules/allow-heading.test.ts
+++ b/packages/eslint-markdown/src/rules/allow-heading.test.ts
@@ -39,28 +39,6 @@ ruleTester('allow-heading', rule, {
 
     // Options
     {
-      name: 'Headings should not be reported when false is given',
-      code: `
-# Hello
-## World
-### Hello World
-#### Hello World
-##### Hello World
-###### Hello World
-`,
-      options: [
-        {
-          h1: false,
-          h2: false,
-          h3: false,
-          h4: false,
-          h5: false,
-          h6: false,
-        },
-      ],
-    },
-
-    {
       name: 'Headings should not be reported when they are allowed',
       code: `
 # Hello
@@ -83,12 +61,37 @@ ruleTester('allow-heading', rule, {
 `,
       options: [
         {
-          h1: ['Hello', 'World'],
-          h2: ['Hello', 'World'],
-          h3: ['Hello', 'World'],
-          h4: ['Hello', 'World'],
-          h5: ['Hello', 'World'],
-          h6: ['Hello', 'World'],
+          h1: { allow: [/^# (?:Hello|World)$/u] },
+          h2: { allow: [/^## (?:Hello|World)$/u] },
+          h3: { allow: [/^### (?:Hello|World)$/u] },
+          h4: { allow: [/^#### (?:Hello|World)$/u] },
+          h5: { allow: [/^##### (?:Hello|World)$/u] },
+          h6: { allow: [/^###### (?:Hello|World)$/u] },
+        },
+      ],
+    },
+    {
+      name: 'Headings should not be reported when they are not disallowed',
+      code: `
+# Hello
+## World
+`,
+      options: [
+        {
+          h1: { disallow: [/Foo/u] },
+          h2: { disallow: [/Foo/u] },
+        },
+      ],
+    },
+    {
+      name: 'Headings should not be reported when they are allowed and not disallowed',
+      code: '# Hello',
+      options: [
+        {
+          h1: {
+            allow: [/^# Hello$/u],
+            disallow: [/^# World$/u],
+          },
         },
       ],
     },
@@ -97,11 +100,11 @@ ruleTester('allow-heading', rule, {
   invalid: [
     // Basic: allow heading
     {
-      name: 'Headings should be reported when they are not allowed - h1',
+      name: 'ATX: h1 heading should be reported when it is not allowed',
       code: '# Hello',
       options: [
         {
-          h1: ['World'],
+          h1: { allow: [/^# World$/u] },
         },
       ],
       errors: [
@@ -111,16 +114,16 @@ ruleTester('allow-heading', rule, {
           column: 1,
           endLine: 1,
           endColumn: 8,
-          data: { heading: 'Hello', allow: '`World`' },
+          data: { depth: '1', heading: '# Hello', allow: '`/^# World$/u`' },
         },
       ],
     },
     {
-      name: 'Headings should be reported when they are not allowed - h2',
+      name: 'ATX: h2 heading should be reported when it is not allowed',
       code: '## Hello',
       options: [
         {
-          h2: ['World'],
+          h2: { allow: [/^## World$/u] },
         },
       ],
       errors: [
@@ -130,16 +133,16 @@ ruleTester('allow-heading', rule, {
           column: 1,
           endLine: 1,
           endColumn: 9,
-          data: { heading: 'Hello', allow: '`World`' },
+          data: { depth: '2', heading: '## Hello', allow: '`/^## World$/u`' },
         },
       ],
     },
     {
-      name: 'Headings should be reported when they are not allowed - h3',
+      name: 'ATX: h3 heading should be reported when it is not allowed',
       code: '### Hello',
       options: [
         {
-          h3: ['World'],
+          h3: { allow: [/^### World$/u] },
         },
       ],
       errors: [
@@ -149,16 +152,16 @@ ruleTester('allow-heading', rule, {
           column: 1,
           endLine: 1,
           endColumn: 10,
-          data: { heading: 'Hello', allow: '`World`' },
+          data: { depth: '3', heading: '### Hello', allow: '`/^### World$/u`' },
         },
       ],
     },
     {
-      name: 'Headings should be reported when they are not allowed - h4',
+      name: 'ATX: h4 heading should be reported when it is not allowed',
       code: '#### Hello',
       options: [
         {
-          h4: ['World'],
+          h4: { allow: [/^#### World$/u] },
         },
       ],
       errors: [
@@ -168,16 +171,16 @@ ruleTester('allow-heading', rule, {
           column: 1,
           endLine: 1,
           endColumn: 11,
-          data: { heading: 'Hello', allow: '`World`' },
+          data: { depth: '4', heading: '#### Hello', allow: '`/^#### World$/u`' },
         },
       ],
     },
     {
-      name: 'Headings should be reported when they are not allowed - h5',
+      name: 'ATX: h5 heading should be reported when it is not allowed',
       code: '##### Hello',
       options: [
         {
-          h5: ['World'],
+          h5: { allow: [/^##### World$/u] },
         },
       ],
       errors: [
@@ -187,16 +190,16 @@ ruleTester('allow-heading', rule, {
           column: 1,
           endLine: 1,
           endColumn: 12,
-          data: { heading: 'Hello', allow: '`World`' },
+          data: { depth: '5', heading: '##### Hello', allow: '`/^##### World$/u`' },
         },
       ],
     },
     {
-      name: 'Headings should be reported when they are not allowed - h6',
+      name: 'ATX: h6 heading should be reported when it is not allowed',
       code: '###### Hello',
       options: [
         {
-          h6: ['World'],
+          h6: { allow: [/^###### World$/u] },
         },
       ],
       errors: [
@@ -206,171 +209,90 @@ ruleTester('allow-heading', rule, {
           column: 1,
           endLine: 1,
           endColumn: 13,
-          data: { heading: 'Hello', allow: '`World`' },
+          data: { depth: '6', heading: '###### Hello', allow: '`/^###### World$/u`' },
         },
       ],
     },
 
-    // Basic: allow heading depth
+    // Basic: disallow heading
     {
-      name: 'Specific depth headings should be reported entirely when empty array option is given - h1',
-      code: '# Hello\n# World',
+      name: 'Heading should be reported when it is disallowed',
+      code: '# Hello',
       options: [
         {
-          h1: [],
+          h1: { disallow: [/^# Hello$/u] },
         },
       ],
       errors: [
         {
-          messageId: 'allowHeadingDepth',
+          messageId: 'disallowHeading',
           line: 1,
           column: 1,
           endLine: 1,
           endColumn: 8,
-          data: { depth: 1 },
+          data: { depth: '1', heading: '# Hello', disallow: '`/^# Hello$/u`' },
         },
+      ],
+    },
+
+    // Basic: allow and disallow heading
+    {
+      name: 'Heading should be reported when it is not allowed and is disallowed',
+      code: '# Hello',
+      options: [
         {
-          messageId: 'allowHeadingDepth',
-          line: 2,
+          h1: {
+            allow: [/^# World$/u],
+            disallow: [/^# Hello$/u],
+          },
+        },
+      ],
+      errors: [
+        {
+          messageId: 'allowHeading',
+          line: 1,
           column: 1,
-          endLine: 2,
+          endLine: 1,
           endColumn: 8,
-          data: { depth: 1 },
+          data: { depth: '1', heading: '# Hello', allow: '`/^# World$/u`' },
+        },
+        {
+          messageId: 'disallowHeading',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 8,
+          data: { depth: '1', heading: '# Hello', disallow: '`/^# Hello$/u`' },
         },
       ],
     },
+
+    // Edge cases
     {
-      name: 'Specific depth headings should be reported entirely when empty array option is given - h2',
-      code: '## Hello\n## World',
+      name: 'Headings should be reported when empty allow array is given',
+      code: '# Hello\n## World',
       options: [
         {
-          h2: [],
+          h1: { allow: [] },
+          h2: { allow: [] },
         },
       ],
       errors: [
         {
-          messageId: 'allowHeadingDepth',
+          messageId: 'allowHeading',
           line: 1,
           column: 1,
           endLine: 1,
-          endColumn: 9,
-          data: { depth: 2 },
+          endColumn: 8,
+          data: { depth: '1', heading: '# Hello', allow: '' },
         },
         {
-          messageId: 'allowHeadingDepth',
+          messageId: 'allowHeading',
           line: 2,
           column: 1,
           endLine: 2,
           endColumn: 9,
-          data: { depth: 2 },
-        },
-      ],
-    },
-    {
-      name: 'Specific depth headings should be reported entirely when empty array option is given - h3',
-      code: '### Hello\n### World',
-      options: [
-        {
-          h3: [],
-        },
-      ],
-      errors: [
-        {
-          messageId: 'allowHeadingDepth',
-          line: 1,
-          column: 1,
-          endLine: 1,
-          endColumn: 10,
-          data: { depth: 3 },
-        },
-        {
-          messageId: 'allowHeadingDepth',
-          line: 2,
-          column: 1,
-          endLine: 2,
-          endColumn: 10,
-          data: { depth: 3 },
-        },
-      ],
-    },
-    {
-      name: 'Specific depth headings should be reported entirely when empty array option is given - h4',
-      code: '#### Hello\n#### World',
-      options: [
-        {
-          h4: [],
-        },
-      ],
-      errors: [
-        {
-          messageId: 'allowHeadingDepth',
-          line: 1,
-          column: 1,
-          endLine: 1,
-          endColumn: 11,
-          data: { depth: 4 },
-        },
-        {
-          messageId: 'allowHeadingDepth',
-          line: 2,
-          column: 1,
-          endLine: 2,
-          endColumn: 11,
-          data: { depth: 4 },
-        },
-      ],
-    },
-    {
-      name: 'Specific depth headings should be reported entirely when empty array option is given - h5',
-      code: '##### Hello\n##### World',
-      options: [
-        {
-          h5: [],
-        },
-      ],
-      errors: [
-        {
-          messageId: 'allowHeadingDepth',
-          line: 1,
-          column: 1,
-          endLine: 1,
-          endColumn: 12,
-          data: { depth: 5 },
-        },
-        {
-          messageId: 'allowHeadingDepth',
-          line: 2,
-          column: 1,
-          endLine: 2,
-          endColumn: 12,
-          data: { depth: 5 },
-        },
-      ],
-    },
-    {
-      name: 'Specific depth headings should be reported entirely when empty array option is given - h6',
-      code: '###### Hello\n###### World',
-      options: [
-        {
-          h6: [],
-        },
-      ],
-      errors: [
-        {
-          messageId: 'allowHeadingDepth',
-          line: 1,
-          column: 1,
-          endLine: 1,
-          endColumn: 13,
-          data: { depth: 6 },
-        },
-        {
-          messageId: 'allowHeadingDepth',
-          line: 2,
-          column: 1,
-          endLine: 2,
-          endColumn: 13,
-          data: { depth: 6 },
+          data: { depth: '2', heading: '## World', allow: '' },
         },
       ],
     },

--- a/packages/eslint-markdown/src/rules/allow-heading.ts
+++ b/packages/eslint-markdown/src/rules/allow-heading.ts
@@ -26,6 +26,8 @@ type MessageIds = 'allowHeading' | 'disallowHeading';
 // Helper
 // --------------------------------------------------------------------------------
 
+const statefulRegexFlagRegex = /[gy]/u;
+
 const headingOptionsSchema = {
   type: 'object',
   properties: {
@@ -46,6 +48,18 @@ const headingOptionsSchema = {
   },
   additionalProperties: false,
 } as const;
+
+/**
+ * Tests a regex without mutating the state stored in its `lastIndex`.
+ * @param regex Regex to test.
+ * @param text Text to test.
+ * @returns Whether the regex matches the text.
+ */
+function testRegexStateless(regex: RegExp, text: string) {
+  return statefulRegexFlagRegex.test(regex.flags)
+    ? new RegExp(regex).test(text)
+    : regex.test(text);
+}
 
 // --------------------------------------------------------------------------------
 // Rule Definition
@@ -118,7 +132,7 @@ export default {
         const { allow, disallow } = headingMap[depth];
         const headingText = sourceCode.getText(node);
 
-        if (!allow.some(regex => regex.test(headingText))) {
+        if (!allow.some(regex => testRegexStateless(regex, headingText))) {
           context.report({
             node,
             messageId: 'allowHeading',
@@ -130,7 +144,7 @@ export default {
           });
         }
 
-        if (disallow.some(regex => regex.test(headingText))) {
+        if (disallow.some(regex => testRegexStateless(regex, headingText))) {
           context.report({
             node,
             messageId: 'disallowHeading',

--- a/packages/eslint-markdown/src/rules/allow-heading.ts
+++ b/packages/eslint-markdown/src/rules/allow-heading.ts
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Rule to enforce the use of allowed text for headings.
+ * @fileoverview Rule to enforce the use of allowed or disallowed headings.
  * @author lumir(lumirlumir)
  */
 
@@ -7,6 +7,7 @@
 // Import
 // --------------------------------------------------------------------------------
 
+import type { Heading } from 'mdast';
 import { URL_RULE_DOCS } from '../core/constants.js';
 import type { RuleModule } from '../core/types.js';
 
@@ -14,14 +15,37 @@ import type { RuleModule } from '../core/types.js';
 // Typedef
 // --------------------------------------------------------------------------------
 
-type RuleOptions = [Record<'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6', false | string[]>];
-type MessageIds = 'allowHeading' | 'allowHeadingDepth';
+export interface HeadingOptions {
+  allow: RegExp[];
+  disallow: RegExp[];
+}
+type RuleOptions = [Record<`h${Heading['depth']}`, HeadingOptions>];
+type MessageIds = 'allowHeading' | 'disallowHeading';
 
 // --------------------------------------------------------------------------------
-// Helpers
+// Helper
 // --------------------------------------------------------------------------------
 
-const headingRegex = /^#{1,6}\s+/u;
+const headingOptionsSchema = {
+  type: 'object',
+  properties: {
+    allow: {
+      type: 'array',
+      items: {
+        type: 'object',
+      },
+      uniqueItems: true,
+    },
+    disallow: {
+      type: 'array',
+      items: {
+        type: 'object',
+      },
+      uniqueItems: true,
+    },
+  },
+  additionalProperties: false,
+} as const;
 
 // --------------------------------------------------------------------------------
 // Rule Definition
@@ -32,7 +56,7 @@ export default {
     type: 'problem',
 
     docs: {
-      description: 'Enforce the use of allowed text for headings',
+      description: 'Enforce the use of allowed or disallowed headings',
       url: URL_RULE_DOCS('allow-heading'),
       recommended: false,
       stylistic: false,
@@ -42,78 +66,12 @@ export default {
       {
         type: 'object',
         properties: {
-          h1: {
-            oneOf: [
-              {
-                enum: [false],
-              },
-              {
-                type: 'array',
-                items: { type: 'string' },
-                uniqueItems: true,
-              },
-            ],
-          },
-          h2: {
-            oneOf: [
-              {
-                enum: [false],
-              },
-              {
-                type: 'array',
-                items: { type: 'string' },
-                uniqueItems: true,
-              },
-            ],
-          },
-          h3: {
-            oneOf: [
-              {
-                enum: [false],
-              },
-              {
-                type: 'array',
-                items: { type: 'string' },
-                uniqueItems: true,
-              },
-            ],
-          },
-          h4: {
-            oneOf: [
-              {
-                enum: [false],
-              },
-              {
-                type: 'array',
-                items: { type: 'string' },
-                uniqueItems: true,
-              },
-            ],
-          },
-          h5: {
-            oneOf: [
-              {
-                enum: [false],
-              },
-              {
-                type: 'array',
-                items: { type: 'string' },
-                uniqueItems: true,
-              },
-            ],
-          },
-          h6: {
-            oneOf: [
-              {
-                enum: [false],
-              },
-              {
-                type: 'array',
-                items: { type: 'string' },
-                uniqueItems: true,
-              },
-            ],
-          },
+          h1: headingOptionsSchema,
+          h2: headingOptionsSchema,
+          h3: headingOptionsSchema,
+          h4: headingOptionsSchema,
+          h5: headingOptionsSchema,
+          h6: headingOptionsSchema,
         },
         additionalProperties: false,
       },
@@ -121,19 +79,20 @@ export default {
 
     defaultOptions: [
       {
-        h1: false,
-        h2: false,
-        h3: false,
-        h4: false,
-        h5: false,
-        h6: false,
+        h1: { allow: [/.*/u], disallow: [] },
+        h2: { allow: [/.*/u], disallow: [] },
+        h3: { allow: [/.*/u], disallow: [] },
+        h4: { allow: [/.*/u], disallow: [] },
+        h5: { allow: [/.*/u], disallow: [] },
+        h6: { allow: [/.*/u], disallow: [] },
       },
     ],
 
     messages: {
       allowHeading:
-        'The heading text `{{ heading }}` is not allowed. Please use one of the following text: {{ allow }}.',
-      allowHeadingDepth: 'The heading depth `h{{ depth }}` is not allowed.',
+        'The level {{ depth }} heading `{{ heading }}` is not in the list of allowed headings. (Allow: {{ allow }}).',
+      disallowHeading:
+        'The level {{ depth }} heading `{{ heading }}` is in the list of disallowed headings. (Disallow: {{ disallow }}).',
     },
 
     language: 'markdown',
@@ -142,6 +101,7 @@ export default {
   },
 
   create(context) {
+    const { sourceCode } = context;
     const [{ h1, h2, h3, h4, h5, h6 }] = context.options;
     const headingMap = {
       1: h1,
@@ -150,36 +110,34 @@ export default {
       4: h4,
       5: h5,
       6: h6,
-    };
+    } as const satisfies Record<Heading['depth'], HeadingOptions>;
 
     return {
       heading(node) {
-        const actualHeadingText = context.sourceCode
-          .getText(node)
-          .replace(headingRegex, '');
-        const expectedHeadingTexts = headingMap[node.depth];
+        const { depth } = node;
+        const { allow, disallow } = headingMap[depth];
+        const headingText = sourceCode.getText(node);
 
-        if (expectedHeadingTexts === false) return;
-
-        if (expectedHeadingTexts.length === 0) {
+        if (!allow.some(regex => regex.test(headingText))) {
           context.report({
             node,
-
-            messageId: 'allowHeadingDepth',
-
+            messageId: 'allowHeading',
             data: {
-              depth: String(node.depth),
+              depth,
+              heading: headingText,
+              allow: allow.map(regex => `\`${regex}\``).join(', '),
             },
           });
-        } else if (!expectedHeadingTexts.includes(actualHeadingText)) {
+        }
+
+        if (disallow.some(regex => regex.test(headingText))) {
           context.report({
             node,
-
-            messageId: 'allowHeading',
-
+            messageId: 'disallowHeading',
             data: {
-              heading: actualHeadingText,
-              allow: expectedHeadingTexts.map(text => `\`${text}\``).join(', '),
+              depth,
+              heading: headingText,
+              disallow: disallow.map(regex => `\`${regex}\``).join(', '),
             },
           });
         }

--- a/packages/eslint-markdown/src/rules/index.ts
+++ b/packages/eslint-markdown/src/rules/index.ts
@@ -2,7 +2,7 @@
 
 // TODO: Re-enable the commented-out rules once they stabilize.
 
-// import allowHeading from './allow-heading.js';
+import allowHeading from './allow-heading.js';
 import allowImageUrl from './allow-image-url.js';
 import allowLinkUrl from './allow-link-url.js';
 import codeLangShorthand from './code-lang-shorthand.js';
@@ -31,7 +31,7 @@ import requireImageTitle from './require-image-title.js';
 import requireLinkTitle from './require-link-title.js';
 
 export default {
-  // 'allow-heading': allowHeading,
+  'allow-heading': allowHeading,
   'allow-image-url': allowImageUrl,
   'allow-link-url': allowLinkUrl,
   'code-lang-shorthand': codeLangShorthand,

--- a/website/.vitepress/config.js
+++ b/website/.vitepress/config.js
@@ -288,7 +288,7 @@ export default defineConfig({
     // Process only the files inside `docs/rules/`, excluding `index.md`.
     if (
       /^docs\/rules\/(?!index).+/.test(pageData.relativePath) &&
-      !/(?:allow-heading|en-capitalization|no-bold-paragraph)\.md$/.test(
+      !/(?:en-capitalization|no-bold-paragraph)\.md$/.test(
         // TODO: Remove this exclusion when the rules are stabilized.
         pageData.relativePath,
       )

--- a/website/.vitepress/config.js
+++ b/website/.vitepress/config.js
@@ -312,8 +312,8 @@ export default defineConfig({
   ${(rule.meta.dialects.includes('gfm') ?? false) ? '<code class="rule-emoji">🌟 GFM</code>' : ''}
 </p>
 <p>
-  <code class="rule-emoji">🔗 <a target="_blank" href="${URL_RULE_SRC}/${ruleName}.js">Rule Source</a></code>
-  <code class="rule-emoji">🔗 <a target="_blank" href="${URL_RULE_SRC}/${ruleName}.test.js">Test Source</a></code>
+  <code class="rule-emoji">🔗 <a target="_blank" href="${URL_RULE_SRC}/${ruleName}.ts">Rule Source</a></code>
+  <code class="rule-emoji">🔗 <a target="_blank" href="${URL_RULE_SRC}/${ruleName}.test.ts">Test Source</a></code>
 </p>
 <p>
   ${(rule.meta.docs.description ?? '')

--- a/website/docs/rules/allow-heading.md
+++ b/website/docs/rules/allow-heading.md
@@ -26,10 +26,10 @@ This rule doesn't report any errors by default. You must configure it with the a
 
 Examples of **incorrect** code for this rule:
 
-#### With `{ h1: { allow: [/^# Introduction$/u] }, h2: { allow: [/^## (?:Overview|Installation)$/u] } }` Option
+#### With `{ h1: { allow: [/^# Introduction$/] }, h2: { allow: [/^## (?:Overview|Installation)$/] } }` Option
 
-```md [incorrect.md] eslint-check
-<!-- eslint md/allow-heading: ["error", { h1: { allow: [/^# Introduction$/u] }, h2: { allow: [/^## (?:Overview|Installation)$/u] } }] -->
+```md eslint-check
+<!-- eslint md/allow-heading: ["error", { h1: { allow: [/^# Introduction$/] }, h2: { allow: [/^## (?:Overview|Installation)$/] } }] -->
 
 # Introduction
 
@@ -48,7 +48,7 @@ Examples of **incorrect** code for this rule:
 
 If you want to disallow all `h3` headings, you can set the `h3.allow` option to an empty array. This will report any `h3` heading as an error.
 
-```md [incorrect.md] eslint-check
+```md eslint-check
 <!-- eslint md/allow-heading: ["error", { h3: { allow: [] } }] -->
 
 # Introduction
@@ -74,7 +74,7 @@ Examples of **correct** code for this rule:
 
 This rule doesn't report any errors by default. You must configure it with the allowed or disallowed heading patterns you want to enforce.
 
-```md [correct.md] eslint-check
+```md eslint-check
 <!-- eslint md/allow-heading: "error" -->
 
 # Introduction
@@ -84,10 +84,10 @@ This rule doesn't report any errors by default. You must configure it with the a
 ## Installation
 ```
 
-#### With `{ h1: { allow: [/^# Introduction$/u] }, h2: { allow: [/^## (?:Overview|Installation)$/u] } }` Option
+#### With `{ h1: { allow: [/^# Introduction$/] }, h2: { allow: [/^## (?:Overview|Installation)$/] } }` Option
 
-```md [correct.md] eslint-check
-<!-- eslint md/allow-heading: ["error", { h1: { allow: [/^# Introduction$/u] }, h2: { allow: [/^## (?:Overview|Installation)$/u] } }] -->
+```md eslint-check
+<!-- eslint md/allow-heading: ["error", { h1: { allow: [/^# Introduction$/] }, h2: { allow: [/^## (?:Overview|Installation)$/] } }] -->
 
 # Introduction
 
@@ -96,10 +96,10 @@ This rule doesn't report any errors by default. You must configure it with the a
 ## Installation
 ```
 
-#### With `{ h1: { disallow: [/^# Draft$/u] } }` Option
+#### With `{ h1: { disallow: [/^# Draft$/] } }` Option
 
-```md [correct.md] eslint-check
-<!-- eslint md/allow-heading: ["error", { h1: { disallow: [/^# Draft$/u] } }] -->
+```md eslint-check
+<!-- eslint md/allow-heading: ["error", { h1: { disallow: [/^# Draft$/] } }] -->
 
 # H1 Heading
 

--- a/website/docs/rules/allow-heading.md
+++ b/website/docs/rules/allow-heading.md
@@ -3,9 +3,9 @@
 
 ## Rule Details
 
-This rule enforces that heading text content matches predefined allowed values. It allows you to restrict the text of headings at different levels (`h1`-`h6`) to specific sets of allowed strings, ensuring consistency in document structure and terminology across your Markdown files.
+This rule enforces that headings match predefined allowed or disallowed patterns. It allows you to restrict headings at different levels (`h1`-`h6`) to specific sets of regular expressions, ensuring consistency in document structure and terminology across your Markdown files.
 
-The rule examines each heading in the document, extracts its text content, and checks if it appears in the configured allowed list for that heading level. If the heading text is not in the allowed list, the rule reports an error.
+The rule examines each heading in the document and checks its Markdown source text, such as `# Introduction` or `## Overview`, against the configured patterns for that heading level.
 
 This is particularly useful for:
 
@@ -16,7 +16,7 @@ This is particularly useful for:
 
 ::: info
 
-This rule doesn't report any errors by default. You must configure it with the allowed heading values you want to enforce.
+This rule doesn't report any errors by default. You must configure it with the allowed or disallowed heading patterns you want to enforce.
 
 :::
 
@@ -26,10 +26,10 @@ This rule doesn't report any errors by default. You must configure it with the a
 
 Examples of **incorrect** code for this rule:
 
-#### With `{ h1: ["Introduction"], h2: ["Overview", "Installation"] }` Option
+#### With `{ h1: { allow: [/^# Introduction$/u] }, h2: { allow: [/^## (?:Overview|Installation)$/u] } }` Option
 
 ```md [incorrect.md] eslint-check
-<!-- eslint md/allow-heading: ["error", { h1: ["Introduction"], h2: ["Overview", "Installation"] }] -->
+<!-- eslint md/allow-heading: ["error", { h1: { allow: [/^# Introduction$/u] }, h2: { allow: [/^## (?:Overview|Installation)$/u] } }] -->
 
 # Introduction
 
@@ -44,12 +44,12 @@ Examples of **incorrect** code for this rule:
 ### Feature 1
 ```
 
-#### With `{ h3: [] }` Option
+#### With `{ h3: { allow: [] } }` Option
 
-If you want to disallow all `h3` headings, you can set the `h3` option to an empty array. This will report any `h3` heading as an error.
+If you want to disallow all `h3` headings, you can set the `h3.allow` option to an empty array. This will report any `h3` heading as an error.
 
 ```md [incorrect.md] eslint-check
-<!-- eslint md/allow-heading: ["error", { h3: [] }] -->
+<!-- eslint md/allow-heading: ["error", { h3: { allow: [] } }] -->
 
 # Introduction
 
@@ -72,7 +72,7 @@ Examples of **correct** code for this rule:
 
 #### Default
 
-This rule doesn't report any errors by default. You must configure it with the allowed heading values you want to enforce.
+This rule doesn't report any errors by default. You must configure it with the allowed or disallowed heading patterns you want to enforce.
 
 ```md [correct.md] eslint-check
 <!-- eslint md/allow-heading: "error" -->
@@ -84,10 +84,10 @@ This rule doesn't report any errors by default. You must configure it with the a
 ## Installation
 ```
 
-#### With `{ h1: ["Introduction"], h2: ["Overview", "Installation"] }` Option
+#### With `{ h1: { allow: [/^# Introduction$/u] }, h2: { allow: [/^## (?:Overview|Installation)$/u] } }` Option
 
 ```md [correct.md] eslint-check
-<!-- eslint md/allow-heading: ["error", { h1: ["Introduction"], h2: ["Overview", "Installation"] }] -->
+<!-- eslint md/allow-heading: ["error", { h1: { allow: [/^# Introduction$/u] }, h2: { allow: [/^## (?:Overview|Installation)$/u] } }] -->
 
 # Introduction
 
@@ -96,12 +96,10 @@ This rule doesn't report any errors by default. You must configure it with the a
 ## Installation
 ```
 
-#### With `{ h1: false, h2: false, h3: false, h4: false, h5: false, h6: false }` Option
-
-If you want to allow any text for all headings, you can set each heading level to `false`. This will not restrict any headings.
+#### With `{ h1: { disallow: [/^# Draft$/u] } }` Option
 
 ```md [correct.md] eslint-check
-<!-- eslint md/allow-heading: ["error", { h1: false, h2: false, h3: false, h4: false, h5: false, h6: false }] -->
+<!-- eslint md/allow-heading: ["error", { h1: { disallow: [/^# Draft$/u] } }] -->
 
 # H1 Heading
 
@@ -120,56 +118,57 @@ If you want to allow any text for all headings, you can set each heading level t
 
 ```js
 'md/allow-heading': ['error', {
-  h1: false,
-  h2: false,
-  h3: false,
-  h4: false, 
-  h5: false,    
-  h6: false,
+  h1: { allow: [/.*/u], disallow: [] },
+  h2: { allow: [/.*/u], disallow: [] },
+  h3: { allow: [/.*/u], disallow: [] },
+  h4: { allow: [/.*/u], disallow: [] },
+  h5: { allow: [/.*/u], disallow: [] },
+  h6: { allow: [/.*/u], disallow: [] },
 }]
 ```
 
 Each heading level can be configured with:
 
-- `false`: No restrictions for that heading level (any text is allowed).
-- An array of strings: Only these exact strings are allowed for that heading level.
-- An empty array `[]`: No headings at that level are allowed (all headings at that level will be reported).
+- `allow`: Allowed heading patterns. Only headings matching at least one pattern are allowed.
+- `disallow`: Disallowed heading patterns. Headings matching any pattern are reported.
+
+The patterns are tested against the Markdown source text for the entire heading node. For example, `## Overview` matches an `h2` ATX heading with the text `Overview`.
 
 ### `h1`
 
-> Default: `false`
+> Default: `{ allow: [/.*/u], disallow: [] }`
 
-The allowed values for `h1` headings. This can be set to an array of strings to restrict `h1` headings to specific values. If set to an empty array, no `h1` headings are allowed.
+The allowed and disallowed patterns for `h1` headings.
 
 ### `h2`
 
-> Default: `false`
+> Default: `{ allow: [/.*/u], disallow: [] }`
 
-The allowed values for `h2` headings. This can be set to an array of strings to restrict `h2` headings to specific values. If set to an empty array, no `h2` headings are allowed.
+The allowed and disallowed patterns for `h2` headings.
 
 ### `h3`
 
-> Default: `false`
+> Default: `{ allow: [/.*/u], disallow: [] }`
 
-The allowed values for `h3` headings. This can be set to an array of strings to restrict `h3` headings to specific values. If set to an empty array, no `h3` headings are allowed.
+The allowed and disallowed patterns for `h3` headings.
 
 ### `h4`
 
-> Default: `false`
+> Default: `{ allow: [/.*/u], disallow: [] }`
 
-The allowed values for `h4` headings. This can be set to an array of strings to restrict `h4` headings to specific values. If set to an empty array, no `h4` headings are allowed.
+The allowed and disallowed patterns for `h4` headings.
 
 ### `h5`
 
-> Default: `false`
+> Default: `{ allow: [/.*/u], disallow: [] }`
 
-The allowed values for `h5` headings. This can be set to an array of strings to restrict `h5` headings to specific values. If set to an empty array, no `h5` headings are allowed.
+The allowed and disallowed patterns for `h5` headings.
 
 ### `h6`
 
-> Default: `false`
+> Default: `{ allow: [/.*/u], disallow: [] }`
 
-The allowed values for `h6` headings. This can be set to an array of strings to restrict `h6` headings to specific values. If set to an empty array, no `h6` headings are allowed.
+The allowed and disallowed patterns for `h6` headings.
 
 ## When Not To Use It
 


### PR DESCRIPTION
This pull request updates the `md/allow-heading` rule to support both allowed and disallowed heading patterns using regular expressions, improves its configuration flexibility, and re-enables the rule across the codebase and documentation. The changes also update the documentation to reflect the new configuration format and behavior.

**Rule enhancements and configuration:**
- The `md/allow-heading` rule now accepts an object with `allow` and `disallow` arrays of regular expressions for each heading level, instead of only arrays of strings or `false`. This allows for more flexible and powerful heading validation. [[1]](diffhunk://#diff-fc8d30713d952bffeccd5e938b332f60474d26167270c16b9f511cda7f369087L2-R48) [[2]](diffhunk://#diff-fc8d30713d952bffeccd5e938b332f60474d26167270c16b9f511cda7f369087L45-R95) [[3]](diffhunk://#diff-fc8d30713d952bffeccd5e938b332f60474d26167270c16b9f511cda7f369087L35-R59)
- The rule's logic has been updated to check headings against both allowed and disallowed patterns, and to report more descriptive errors.
- The default configuration now allows all headings by default (`{ allow: [/.*/u], disallow: [] }` for each level).

**Codebase and configuration updates:**
- The rule is now re-enabled in the rule index and included in the `all` config and website documentation linting. [[1]](diffhunk://#diff-a606b2d23541d69bcdb9b879f07069cd9dbf8707a82c234a8c1a10fa2153f1a0L5-R5) [[2]](diffhunk://#diff-a606b2d23541d69bcdb9b879f07069cd9dbf8707a82c234a8c1a10fa2153f1a0L34-R34) [[3]](diffhunk://#diff-809f565c4dfc43f902fe1daa0735b77409a03b5e594ff68332deb8fb969c2f7aR32) [[4]](diffhunk://#diff-a32a0887ed9d1d707bbb3b845b7df7fd40e673c47e7b60a3ebd896b68d3b8839L56-L72)
- The exclusion for `allow-heading` in the website build is removed, so the rule is now enforced on documentation.

**Documentation improvements:**
- The documentation for `md/allow-heading` is updated to describe the new configuration structure and behavior, including examples of using regular expressions for allowed and disallowed headings. [[1]](diffhunk://#diff-5b4d4ec250e894c1839ae076760fe0c9d3f649aa2d22aea68e4e51e41c6cc007L6-R8) [[2]](diffhunk://#diff-5b4d4ec250e894c1839ae076760fe0c9d3f649aa2d22aea68e4e51e41c6cc007L19-R19) [[3]](diffhunk://#diff-5b4d4ec250e894c1839ae076760fe0c9d3f649aa2d22aea68e4e51e41c6cc007L29-R32) [[4]](diffhunk://#diff-5b4d4ec250e894c1839ae076760fe0c9d3f649aa2d22aea68e4e51e41c6cc007L47-R52) [[5]](diffhunk://#diff-5b4d4ec250e894c1839ae076760fe0c9d3f649aa2d22aea68e4e51e41c6cc007L75-R77) [[6]](diffhunk://#diff-5b4d4ec250e894c1839ae076760fe0c9d3f649aa2d22aea68e4e51e41c6cc007L87-R90) [[7]](diffhunk://#diff-5b4d4ec250e894c1839ae076760fe0c9d3f649aa2d22aea68e4e51e41c6cc007L99-R102) [[8]](diffhunk://#diff-5b4d4ec250e894c1839ae076760fe0c9d3f649aa2d22aea68e4e51e41c6cc007L123-R171)
- Example configurations and explanations are revised to match the new object-based format.

**Other improvements:**
- Website rule source links now point to `.ts` files instead of `.js` files.