### PR TITLE
test(eslint-markdown): replace node assert with vitest assert

### DIFF
--- a/packages/eslint-markdown/src/core/utils/escape-string-regexp.test.ts
+++ b/packages/eslint-markdown/src/core/utils/escape-string-regexp.test.ts
@@ -31,8 +31,7 @@
 // Import
 // --------------------------------------------------------------------------------
 
-import { describe, it } from 'vitest';
-import { match, strictEqual } from 'node:assert';
+import { assert, describe, it } from 'vitest';
 import escapeStringRegexp from './escape-string-regexp.js';
 
 // --------------------------------------------------------------------------------
@@ -41,17 +40,17 @@ import escapeStringRegexp from './escape-string-regexp.js';
 
 describe('escape-string-regexp', () => {
   it('main', () => {
-    strictEqual(
+    assert.strictEqual(
       escapeStringRegexp('\\ ^ $ * + ? . ( ) | { } [ ]'),
       '\\\\ \\^ \\$ \\* \\+ \\? \\. \\( \\) \\| \\{ \\} \\[ \\]',
     );
   });
 
   it('escapes `-` in a way compatible with PCRE', () => {
-    strictEqual(escapeStringRegexp('foo - bar'), 'foo \\x2d bar');
+    assert.strictEqual(escapeStringRegexp('foo - bar'), 'foo \\x2d bar');
   });
 
   it('escapes `-` in a way compatible with the Unicode flag', () => {
-    match('-', new RegExp(escapeStringRegexp('-'), 'u'));
+    assert.match('-', new RegExp(escapeStringRegexp('-'), 'u'));
   });
 });

--- a/packages/eslint-markdown/src/core/utils/html.test.ts
+++ b/packages/eslint-markdown/src/core/utils/html.test.ts
@@ -6,8 +6,7 @@
 // Import
 // --------------------------------------------------------------------------------
 
-import { describe, it } from 'vitest';
-import { ok, strictEqual } from 'node:assert';
+import { assert, describe, it } from 'vitest';
 import getElementsByTagName from './html.js';
 
 // --------------------------------------------------------------------------------
@@ -24,13 +23,13 @@ describe('html', () => {
   it('should parse tag name case-insensitively', () => {
     const elements = getElementsByTagName(html, 'P');
 
-    strictEqual(elements.length, 1);
-    strictEqual(elements[0].tagName, 'p');
+    assert.strictEqual(elements.length, 1);
+    assert.strictEqual(elements[0].tagName, 'p');
   });
 
   it('should have `sourceCodeLocation` property', () => {
     const elements = getElementsByTagName(html, 'p');
 
-    ok(elements[0].sourceCodeLocation);
+    assert.ok(elements[0].sourceCodeLocation);
   });
 });

--- a/packages/eslint-markdown/src/core/utils/is-blank-line.test.ts
+++ b/packages/eslint-markdown/src/core/utils/is-blank-line.test.ts
@@ -6,8 +6,7 @@
 // Import
 // --------------------------------------------------------------------------------
 
-import { describe, it } from 'vitest';
-import { strictEqual } from 'node:assert';
+import { assert, describe, it } from 'vitest';
 import isBlankLine from './is-blank-line.js';
 
 // --------------------------------------------------------------------------------
@@ -17,81 +16,81 @@ import isBlankLine from './is-blank-line.js';
 describe('is-blank-line', () => {
   describe('blank line', () => {
     it('should return `true` for an empty string', () => {
-      strictEqual(isBlankLine(''), true);
+      assert.strictEqual(isBlankLine(''), true);
     });
 
     it('should return `true` for a string containing only a space', () => {
-      strictEqual(isBlankLine(' '), true);
+      assert.strictEqual(isBlankLine(' '), true);
     });
 
     it('should return `true` for a string containing only a tab', () => {
-      strictEqual(isBlankLine('\t'), true);
+      assert.strictEqual(isBlankLine('\t'), true);
     });
 
     it('should return `true` for a string containing multiple tabs', () => {
-      strictEqual(isBlankLine('\t\t\t'), true);
+      assert.strictEqual(isBlankLine('\t\t\t'), true);
     });
 
     it('should return `true` for a string containing mixed spaces and tabs - 1', () => {
-      strictEqual(isBlankLine(' \t '), true);
+      assert.strictEqual(isBlankLine(' \t '), true);
     });
 
     it('should return `true` for a string containing mixed spaces and tabs - 2', () => {
-      strictEqual(isBlankLine(' \t    \t \t  '), true);
+      assert.strictEqual(isBlankLine(' \t    \t \t  '), true);
     });
 
     it('should return `true` for a single blockquote marker', () => {
-      strictEqual(isBlankLine('>', 0), true);
+      assert.strictEqual(isBlankLine('>', 0), true);
     });
 
     it('should return `true` for a top-level blockquote marker with only trailing spaces', () => {
-      strictEqual(isBlankLine('>   ', 0), true);
+      assert.strictEqual(isBlankLine('>   ', 0), true);
     });
 
     it('should return `true` for nested blockquote markers with spaces between markers', () => {
-      strictEqual(isBlankLine(' >   > \t ', 1), true);
+      assert.strictEqual(isBlankLine(' >   > \t ', 1), true);
     });
   });
 
   describe('non-blank line', () => {
     it('should return `false` for a string containing a character', () => {
-      strictEqual(isBlankLine('a'), false);
+      assert.strictEqual(isBlankLine('a'), false);
     });
 
     it('should return `false` for a string containing whitespace before a character', () => {
-      strictEqual(isBlankLine(' \ta'), false);
+      assert.strictEqual(isBlankLine(' \ta'), false);
     });
 
     it('should return `false` for a string containing whitespace after a character', () => {
-      strictEqual(isBlankLine('a\t '), false);
+      assert.strictEqual(isBlankLine('a\t '), false);
     });
 
     it('should return `false` for a newline character', () => {
-      strictEqual(isBlankLine('\n'), false);
+      assert.strictEqual(isBlankLine('\n'), false);
     });
 
     it('should return `false` for a carriage return character', () => {
-      strictEqual(isBlankLine('\r'), false);
+      assert.strictEqual(isBlankLine('\r'), false);
     });
 
     it('should return `false` for a form feed character', () => {
-      strictEqual(isBlankLine('\f'), false);
+      assert.strictEqual(isBlankLine('\f'), false);
     });
 
     it('should return `false` for a non-breaking space', () => {
-      strictEqual(isBlankLine('\u00A0'), false);
+      assert.strictEqual(isBlankLine('\u00A0'), false);
     });
 
     it('should return `false` for a string containing text after a blockquote marker', () => {
-      strictEqual(isBlankLine('> a', 0), false);
+      assert.strictEqual(isBlankLine('> a', 0), false);
     });
 
     it('should return `false` for a string containing text after a blockquote marker and another blockquote marker', () => {
-      strictEqual(isBlankLine('> a >', 0), false);
+      assert.strictEqual(isBlankLine('> a >', 0), false);
     });
 
     it('should return `false` when a nested blockquote marker remains after the given depth', () => {
-      strictEqual(isBlankLine('> \\>', 0), false);
+      assert.strictEqual(isBlankLine('> \\>', 0), false);
     });
   });
 });

--- a/packages/eslint-markdown/src/core/utils/skip-ranges.test.ts
+++ b/packages/eslint-markdown/src/core/utils/skip-ranges.test.ts
@@ -10,8 +10,7 @@
 // Import
 // --------------------------------------------------------------------------------
 
-import { describe, it } from 'vitest';
-import { strictEqual } from 'node:assert';
+import { assert, describe, it } from 'vitest';
 import SkipRanges from './skip-ranges.js';
 
 // --------------------------------------------------------------------------------
@@ -35,40 +34,40 @@ describe('skip-ranges', () => {
 
         skipRanges.push([0, 32]);
 
-        strictEqual(skipRanges.includes(0), true);
-        strictEqual(skipRanges.includes(1), true);
-        strictEqual(skipRanges.includes(2), true);
-        strictEqual(skipRanges.includes(3), true);
-        strictEqual(skipRanges.includes(4), true);
-        strictEqual(skipRanges.includes(5), true);
-        strictEqual(skipRanges.includes(6), true);
-        strictEqual(skipRanges.includes(7), true);
-        strictEqual(skipRanges.includes(8), true);
-        strictEqual(skipRanges.includes(9), true);
-        strictEqual(skipRanges.includes(10), true);
-        strictEqual(skipRanges.includes(11), true);
-        strictEqual(skipRanges.includes(12), true);
-        strictEqual(skipRanges.includes(13), true);
-        strictEqual(skipRanges.includes(14), true);
-        strictEqual(skipRanges.includes(15), true);
-        strictEqual(skipRanges.includes(16), true);
-        strictEqual(skipRanges.includes(17), true);
-        strictEqual(skipRanges.includes(18), true);
-        strictEqual(skipRanges.includes(19), true);
-        strictEqual(skipRanges.includes(20), true);
-        strictEqual(skipRanges.includes(21), true);
-        strictEqual(skipRanges.includes(22), true);
-        strictEqual(skipRanges.includes(23), true);
-        strictEqual(skipRanges.includes(24), true);
-        strictEqual(skipRanges.includes(25), true);
-        strictEqual(skipRanges.includes(26), true);
-        strictEqual(skipRanges.includes(27), true);
-        strictEqual(skipRanges.includes(28), true);
-        strictEqual(skipRanges.includes(29), true);
-        strictEqual(skipRanges.includes(30), true);
-        strictEqual(skipRanges.includes(31), true);
-        strictEqual(skipRanges.includes(32), false);
-        strictEqual(skipRanges.includes(33), false);
+        assert.strictEqual(skipRanges.includes(0), true);
+        assert.strictEqual(skipRanges.includes(1), true);
+        assert.strictEqual(skipRanges.includes(2), true);
+        assert.strictEqual(skipRanges.includes(3), true);
+        assert.strictEqual(skipRanges.includes(4), true);
+        assert.strictEqual(skipRanges.includes(5), true);
+        assert.strictEqual(skipRanges.includes(6), true);
+        assert.strictEqual(skipRanges.includes(7), true);
+        assert.strictEqual(skipRanges.includes(8), true);
+        assert.strictEqual(skipRanges.includes(9), true);
+        assert.strictEqual(skipRanges.includes(10), true);
+        assert.strictEqual(skipRanges.includes(11), true);
+        assert.strictEqual(skipRanges.includes(12), true);
+        assert.strictEqual(skipRanges.includes(13), true);
+        assert.strictEqual(skipRanges.includes(14), true);
+        assert.strictEqual(skipRanges.includes(15), true);
+        assert.strictEqual(skipRanges.includes(16), true);
+        assert.strictEqual(skipRanges.includes(17), true);
+        assert.strictEqual(skipRanges.includes(18), true);
+        assert.strictEqual(skipRanges.includes(19), true);
+        assert.strictEqual(skipRanges.includes(20), true);
+        assert.strictEqual(skipRanges.includes(21), true);
+        assert.strictEqual(skipRanges.includes(22), true);
+        assert.strictEqual(skipRanges.includes(23), true);
+        assert.strictEqual(skipRanges.includes(24), true);
+        assert.strictEqual(skipRanges.includes(25), true);
+        assert.strictEqual(skipRanges.includes(26), true);
+        assert.strictEqual(skipRanges.includes(27), true);
+        assert.strictEqual(skipRanges.includes(28), true);
+        assert.strictEqual(skipRanges.includes(29), true);
+        assert.strictEqual(skipRanges.includes(30), true);
+        assert.strictEqual(skipRanges.includes(31), true);
+        assert.strictEqual(skipRanges.includes(32), false);
+        assert.strictEqual(skipRanges.includes(33), false);
       });
     });
 
@@ -78,16 +77,16 @@ describe('skip-ranges', () => {
 
         skipRanges.push([0, 7]);
 
-        strictEqual(skipRanges.includes(0), true);
-        strictEqual(skipRanges.includes(1), true);
-        strictEqual(skipRanges.includes(2), true);
-        strictEqual(skipRanges.includes(3), true);
-        strictEqual(skipRanges.includes(4), true);
-        strictEqual(skipRanges.includes(5), true);
-        strictEqual(skipRanges.includes(6), true);
-        strictEqual(skipRanges.includes(7), false);
-        strictEqual(skipRanges.includes(8), false);
-        strictEqual(skipRanges.includes(9), false);
+        assert.strictEqual(skipRanges.includes(0), true);
+        assert.strictEqual(skipRanges.includes(1), true);
+        assert.strictEqual(skipRanges.includes(2), true);
+        assert.strictEqual(skipRanges.includes(3), true);
+        assert.strictEqual(skipRanges.includes(4), true);
+        assert.strictEqual(skipRanges.includes(5), true);
+        assert.strictEqual(skipRanges.includes(6), true);
+        assert.strictEqual(skipRanges.includes(7), false);
+        assert.strictEqual(skipRanges.includes(8), false);
+        assert.strictEqual(skipRanges.includes(9), false);
       });
     });
 
@@ -97,17 +96,17 @@ describe('skip-ranges', () => {
 
         skipRanges.push([0, 9]);
 
-        strictEqual(skipRanges.includes(0), true);
-        strictEqual(skipRanges.includes(1), true);
-        strictEqual(skipRanges.includes(2), true);
-        strictEqual(skipRanges.includes(3), true);
-        strictEqual(skipRanges.includes(4), true);
-        strictEqual(skipRanges.includes(5), true);
-        strictEqual(skipRanges.includes(6), true);
-        strictEqual(skipRanges.includes(7), true);
-        strictEqual(skipRanges.includes(8), true);
-        strictEqual(skipRanges.includes(9), false);
-        strictEqual(skipRanges.includes(10), false);
+        assert.strictEqual(skipRanges.includes(0), true);
+        assert.strictEqual(skipRanges.includes(1), true);
+        assert.strictEqual(skipRanges.includes(2), true);
+        assert.strictEqual(skipRanges.includes(3), true);
+        assert.strictEqual(skipRanges.includes(4), true);
+        assert.strictEqual(skipRanges.includes(5), true);
+        assert.strictEqual(skipRanges.includes(6), true);
+        assert.strictEqual(skipRanges.includes(7), true);
+        assert.strictEqual(skipRanges.includes(8), true);
+        assert.strictEqual(skipRanges.includes(9), false);
+        assert.strictEqual(skipRanges.includes(10), false);
       });
     });
 
@@ -117,19 +116,19 @@ describe('skip-ranges', () => {
 
         skipRanges.push([0, 11]);
 
-        strictEqual(skipRanges.includes(0), true);
-        strictEqual(skipRanges.includes(1), true);
-        strictEqual(skipRanges.includes(2), true);
-        strictEqual(skipRanges.includes(3), true);
-        strictEqual(skipRanges.includes(4), true);
-        strictEqual(skipRanges.includes(5), true);
-        strictEqual(skipRanges.includes(6), true);
-        strictEqual(skipRanges.includes(7), true);
-        strictEqual(skipRanges.includes(8), true);
-        strictEqual(skipRanges.includes(9), true);
-        strictEqual(skipRanges.includes(10), true);
-        strictEqual(skipRanges.includes(11), false);
-        strictEqual(skipRanges.includes(12), false);
+        assert.strictEqual(skipRanges.includes(0), true);
+        assert.strictEqual(skipRanges.includes(1), true);
+        assert.strictEqual(skipRanges.includes(2), true);
+        assert.strictEqual(skipRanges.includes(3), true);
+        assert.strictEqual(skipRanges.includes(4), true);
+        assert.strictEqual(skipRanges.includes(5), true);
+        assert.strictEqual(skipRanges.includes(6), true);
+        assert.strictEqual(skipRanges.includes(7), true);
+        assert.strictEqual(skipRanges.includes(8), true);
+        assert.strictEqual(skipRanges.includes(9), true);
+        assert.strictEqual(skipRanges.includes(10), true);
+        assert.strictEqual(skipRanges.includes(11), false);
+        assert.strictEqual(skipRanges.includes(12), false);
       });
     });
   });

--- a/packages/eslint-markdown/src/index.test.ts
+++ b/packages/eslint-markdown/src/index.test.ts
@@ -7,8 +7,7 @@
 // Import
 // --------------------------------------------------------------------------------
 
-import { describe, it } from 'vitest';
-import { ok, strictEqual } from 'node:assert';
+import { assert, describe, it } from 'vitest';
 
 import { defineConfig } from 'eslint/config';
 import { Linter } from 'eslint/universal';
@@ -24,49 +23,49 @@ import packageJson from '../package.json' with { type: 'json' };
 describe('index', () => {
   describe('package.json', () => {
     it('should have `sideEffects: false`', () => {
-      strictEqual(packageJson.sideEffects, false);
+      assert.strictEqual(packageJson.sideEffects, false);
     });
   });
 
   describe('Basic', () => {
     it('should have correct meta information', () => {
-      strictEqual(md.meta.name, 'eslint-markdown');
-      strictEqual(typeof md.meta.version, 'string');
+      assert.strictEqual(md.meta.name, 'eslint-markdown');
+      assert.strictEqual(typeof md.meta.version, 'string');
     });
 
     it('should have rules', () => {
-      ok(md.rules);
-      strictEqual(typeof md.rules, 'object');
-      strictEqual(Object.keys(md.rules).length > 0, true);
+      assert.ok(md.rules);
+      assert.strictEqual(typeof md.rules, 'object');
+      assert.strictEqual(Object.keys(md.rules).length > 0, true);
     });
 
     it('should have configs', () => {
-      ok(md.configs);
-      ok(md.configs.all);
-      ok(md.configs.base);
-      ok(md.configs.recommended);
-      ok(md.configs.stylistic);
-      strictEqual(typeof md.configs, 'object');
-      strictEqual(Object.keys(md.configs).length > 0, true);
+      assert.ok(md.configs);
+      assert.ok(md.configs.all);
+      assert.ok(md.configs.base);
+      assert.ok(md.configs.recommended);
+      assert.ok(md.configs.stylistic);
+      assert.strictEqual(typeof md.configs, 'object');
+      assert.strictEqual(Object.keys(md.configs).length > 0, true);
     });
   });
 
   describe('Config rules should use `md/` prefix', () => {
     it('`all` configuration', () => {
       for (const allConfigRuleName of Object.keys(md.configs.all.rules)) {
-        strictEqual(allConfigRuleName.startsWith('md/'), true);
+        assert.strictEqual(allConfigRuleName.startsWith('md/'), true);
       }
     });
 
     it('`recommended` configuration', () => {
       for (const recommendedConfigRuleName of Object.keys(md.configs.recommended.rules)) {
-        strictEqual(recommendedConfigRuleName.startsWith('md/'), true);
+        assert.strictEqual(recommendedConfigRuleName.startsWith('md/'), true);
       }
     });
 
     it('`stylistic` configuration', () => {
       for (const stylisticConfigRuleName of Object.keys(md.configs.stylistic.rules)) {
-        strictEqual(stylisticConfigRuleName.startsWith('md/'), true);
+        assert.strictEqual(stylisticConfigRuleName.startsWith('md/'), true);
       }
     });
   });
@@ -87,13 +86,13 @@ describe('index', () => {
         filename: 'test.md',
       });
 
-      strictEqual(extendsStyleConfigResult.length, 1);
-      strictEqual(extendsStyleConfigResult[0].ruleId, 'md/no-double-space');
-      strictEqual(extendsStyleConfigResult[0].severity, 2);
-      strictEqual(extendsStyleConfigResult[0].line, 1);
-      strictEqual(extendsStyleConfigResult[0].column, 3);
-      strictEqual(extendsStyleConfigResult[0].endLine, 1);
-      strictEqual(extendsStyleConfigResult[0].endColumn, 5);
+      assert.strictEqual(extendsStyleConfigResult.length, 1);
+      assert.strictEqual(extendsStyleConfigResult[0].ruleId, 'md/no-double-space');
+      assert.strictEqual(extendsStyleConfigResult[0].severity, 2);
+      assert.strictEqual(extendsStyleConfigResult[0].line, 1);
+      assert.strictEqual(extendsStyleConfigResult[0].column, 3);
+      assert.strictEqual(extendsStyleConfigResult[0].endLine, 1);
+      assert.strictEqual(extendsStyleConfigResult[0].endColumn, 5);
     });
 
     it('`all` configuration with `@eslint/markdown` plugin', () => {
@@ -116,19 +115,22 @@ describe('index', () => {
         },
       );
 
-      strictEqual(extendsStyleConfigResult.length, 2);
-      strictEqual(extendsStyleConfigResult[0].ruleId, 'md/no-double-space');
-      strictEqual(extendsStyleConfigResult[0].severity, 2);
-      strictEqual(extendsStyleConfigResult[0].line, 1);
-      strictEqual(extendsStyleConfigResult[0].column, 3);
-      strictEqual(extendsStyleConfigResult[0].endLine, 1);
-      strictEqual(extendsStyleConfigResult[0].endColumn, 5);
-      strictEqual(extendsStyleConfigResult[1].ruleId, 'markdown/no-unused-definitions');
-      strictEqual(extendsStyleConfigResult[1].severity, 2);
-      strictEqual(extendsStyleConfigResult[1].line, 3);
-      strictEqual(extendsStyleConfigResult[1].column, 1);
-      strictEqual(extendsStyleConfigResult[1].endLine, 3);
-      strictEqual(extendsStyleConfigResult[1].endColumn, 11);
+      assert.strictEqual(extendsStyleConfigResult.length, 2);
+      assert.strictEqual(extendsStyleConfigResult[0].ruleId, 'md/no-double-space');
+      assert.strictEqual(extendsStyleConfigResult[0].severity, 2);
+      assert.strictEqual(extendsStyleConfigResult[0].line, 1);
+      assert.strictEqual(extendsStyleConfigResult[0].column, 3);
+      assert.strictEqual(extendsStyleConfigResult[0].endLine, 1);
+      assert.strictEqual(extendsStyleConfigResult[0].endColumn, 5);
+      assert.strictEqual(
+        extendsStyleConfigResult[1].ruleId,
+        'markdown/no-unused-definitions',
+      );
+      assert.strictEqual(extendsStyleConfigResult[1].severity, 2);
+      assert.strictEqual(extendsStyleConfigResult[1].line, 3);
+      assert.strictEqual(extendsStyleConfigResult[1].column, 1);
+      assert.strictEqual(extendsStyleConfigResult[1].endLine, 3);
+      assert.strictEqual(extendsStyleConfigResult[1].endColumn, 11);
     });
 
     it('`base` configuration', () => {
@@ -149,13 +151,13 @@ describe('index', () => {
         filename: 'test.md',
       });
 
-      strictEqual(extendsStyleConfigResult.length, 1);
-      strictEqual(extendsStyleConfigResult[0].ruleId, 'md/no-double-space');
-      strictEqual(extendsStyleConfigResult[0].severity, 2);
-      strictEqual(extendsStyleConfigResult[0].line, 1);
-      strictEqual(extendsStyleConfigResult[0].column, 3);
-      strictEqual(extendsStyleConfigResult[0].endLine, 1);
-      strictEqual(extendsStyleConfigResult[0].endColumn, 5);
+      assert.strictEqual(extendsStyleConfigResult.length, 1);
+      assert.strictEqual(extendsStyleConfigResult[0].ruleId, 'md/no-double-space');
+      assert.strictEqual(extendsStyleConfigResult[0].severity, 2);
+      assert.strictEqual(extendsStyleConfigResult[0].line, 1);
+      assert.strictEqual(extendsStyleConfigResult[0].column, 3);
+      assert.strictEqual(extendsStyleConfigResult[0].endLine, 1);
+      assert.strictEqual(extendsStyleConfigResult[0].endColumn, 5);
     });
 
     it('`base` configuration with `@eslint/markdown` plugin', () => {
@@ -181,19 +183,22 @@ describe('index', () => {
         },
       );
 
-      strictEqual(extendsStyleConfigResult.length, 2);
-      strictEqual(extendsStyleConfigResult[0].ruleId, 'md/no-double-space');
-      strictEqual(extendsStyleConfigResult[0].severity, 2);
-      strictEqual(extendsStyleConfigResult[0].line, 1);
-      strictEqual(extendsStyleConfigResult[0].column, 3);
-      strictEqual(extendsStyleConfigResult[0].endLine, 1);
-      strictEqual(extendsStyleConfigResult[0].endColumn, 5);
-      strictEqual(extendsStyleConfigResult[1].ruleId, 'markdown/no-unused-definitions');
-      strictEqual(extendsStyleConfigResult[1].severity, 2);
-      strictEqual(extendsStyleConfigResult[1].line, 3);
-      strictEqual(extendsStyleConfigResult[1].column, 1);
-      strictEqual(extendsStyleConfigResult[1].endLine, 3);
-      strictEqual(extendsStyleConfigResult[1].endColumn, 11);
+      assert.strictEqual(extendsStyleConfigResult.length, 2);
+      assert.strictEqual(extendsStyleConfigResult[0].ruleId, 'md/no-double-space');
+      assert.strictEqual(extendsStyleConfigResult[0].severity, 2);
+      assert.strictEqual(extendsStyleConfigResult[0].line, 1);
+      assert.strictEqual(extendsStyleConfigResult[0].column, 3);
+      assert.strictEqual(extendsStyleConfigResult[0].endLine, 1);
+      assert.strictEqual(extendsStyleConfigResult[0].endColumn, 5);
+      assert.strictEqual(
+        extendsStyleConfigResult[1].ruleId,
+        'markdown/no-unused-definitions',
+      );
+      assert.strictEqual(extendsStyleConfigResult[1].severity, 2);
+      assert.strictEqual(extendsStyleConfigResult[1].line, 3);
+      assert.strictEqual(extendsStyleConfigResult[1].column, 1);
+      assert.strictEqual(extendsStyleConfigResult[1].endLine, 3);
+      assert.strictEqual(extendsStyleConfigResult[1].endColumn, 11);
     });
 
     it('`recommended` configuration', () => {
@@ -211,13 +216,13 @@ describe('index', () => {
         filename: 'test.md',
       });
 
-      strictEqual(extendsStyleConfigResult.length, 1);
-      strictEqual(extendsStyleConfigResult[0].ruleId, 'md/no-double-space');
-      strictEqual(extendsStyleConfigResult[0].severity, 2);
-      strictEqual(extendsStyleConfigResult[0].line, 1);
-      strictEqual(extendsStyleConfigResult[0].column, 3);
-      strictEqual(extendsStyleConfigResult[0].endLine, 1);
-      strictEqual(extendsStyleConfigResult[0].endColumn, 5);
+      assert.strictEqual(extendsStyleConfigResult.length, 1);
+      assert.strictEqual(extendsStyleConfigResult[0].ruleId, 'md/no-double-space');
+      assert.strictEqual(extendsStyleConfigResult[0].severity, 2);
+      assert.strictEqual(extendsStyleConfigResult[0].line, 1);
+      assert.strictEqual(extendsStyleConfigResult[0].column, 3);
+      assert.strictEqual(extendsStyleConfigResult[0].endLine, 1);
+      assert.strictEqual(extendsStyleConfigResult[0].endColumn, 5);
     });
 
     it('`recommended` configuration with `@eslint/markdown` plugin', () => {
@@ -240,19 +245,22 @@ describe('index', () => {
         },
       );
 
-      strictEqual(extendsStyleConfigResult.length, 2);
-      strictEqual(extendsStyleConfigResult[0].ruleId, 'md/no-double-space');
-      strictEqual(extendsStyleConfigResult[0].severity, 2);
-      strictEqual(extendsStyleConfigResult[0].line, 1);
-      strictEqual(extendsStyleConfigResult[0].column, 3);
-      strictEqual(extendsStyleConfigResult[0].endLine, 1);
-      strictEqual(extendsStyleConfigResult[0].endColumn, 5);
-      strictEqual(extendsStyleConfigResult[1].ruleId, 'markdown/no-unused-definitions');
-      strictEqual(extendsStyleConfigResult[1].severity, 2);
-      strictEqual(extendsStyleConfigResult[1].line, 3);
-      strictEqual(extendsStyleConfigResult[1].column, 1);
-      strictEqual(extendsStyleConfigResult[1].endLine, 3);
-      strictEqual(extendsStyleConfigResult[1].endColumn, 11);
+      assert.strictEqual(extendsStyleConfigResult.length, 2);
+      assert.strictEqual(extendsStyleConfigResult[0].ruleId, 'md/no-double-space');
+      assert.strictEqual(extendsStyleConfigResult[0].severity, 2);
+      assert.strictEqual(extendsStyleConfigResult[0].line, 1);
+      assert.strictEqual(extendsStyleConfigResult[0].column, 3);
+      assert.strictEqual(extendsStyleConfigResult[0].endLine, 1);
+      assert.strictEqual(extendsStyleConfigResult[0].endColumn, 5);
+      assert.strictEqual(
+        extendsStyleConfigResult[1].ruleId,
+        'markdown/no-unused-definitions',
+      );
+      assert.strictEqual(extendsStyleConfigResult[1].severity, 2);
+      assert.strictEqual(extendsStyleConfigResult[1].line, 3);
+      assert.strictEqual(extendsStyleConfigResult[1].column, 1);
+      assert.strictEqual(extendsStyleConfigResult[1].endLine, 3);
+      assert.strictEqual(extendsStyleConfigResult[1].endColumn, 11);
     });
 
     it('`stylistic` configuration', () => {
@@ -270,16 +278,16 @@ describe('index', () => {
         filename: 'test.md',
       });
 
-      strictEqual(extendsStyleConfigResult.length, 1);
-      strictEqual(
+      assert.strictEqual(extendsStyleConfigResult.length, 1);
+      assert.strictEqual(
         extendsStyleConfigResult[0].ruleId,
         'md/consistent-thematic-break-style',
       );
-      strictEqual(extendsStyleConfigResult[0].severity, 2);
-      strictEqual(extendsStyleConfigResult[0].line, 3);
-      strictEqual(extendsStyleConfigResult[0].column, 1);
-      strictEqual(extendsStyleConfigResult[0].endLine, 3);
-      strictEqual(extendsStyleConfigResult[0].endColumn, 4);
+      assert.strictEqual(extendsStyleConfigResult[0].severity, 2);
+      assert.strictEqual(extendsStyleConfigResult[0].line, 3);
+      assert.strictEqual(extendsStyleConfigResult[0].column, 1);
+      assert.strictEqual(extendsStyleConfigResult[0].endLine, 3);
+      assert.strictEqual(extendsStyleConfigResult[0].endColumn, 4);
     });
 
     it('`stylistic` configuration with `@eslint/markdown` plugin', () => {
@@ -302,22 +310,25 @@ describe('index', () => {
         },
       );
 
-      strictEqual(extendsStyleConfigResult.length, 2);
-      strictEqual(
+      assert.strictEqual(extendsStyleConfigResult.length, 2);
+      assert.strictEqual(
         extendsStyleConfigResult[0].ruleId,
         'md/consistent-thematic-break-style',
       );
-      strictEqual(extendsStyleConfigResult[0].severity, 2);
-      strictEqual(extendsStyleConfigResult[0].line, 3);
-      strictEqual(extendsStyleConfigResult[0].column, 1);
-      strictEqual(extendsStyleConfigResult[0].endLine, 3);
-      strictEqual(extendsStyleConfigResult[0].endColumn, 4);
-      strictEqual(extendsStyleConfigResult[1].ruleId, 'markdown/no-unused-definitions');
-      strictEqual(extendsStyleConfigResult[1].severity, 2);
-      strictEqual(extendsStyleConfigResult[1].line, 5);
-      strictEqual(extendsStyleConfigResult[1].column, 1);
-      strictEqual(extendsStyleConfigResult[1].endLine, 5);
-      strictEqual(extendsStyleConfigResult[1].endColumn, 11);
+      assert.strictEqual(extendsStyleConfigResult[0].severity, 2);
+      assert.strictEqual(extendsStyleConfigResult[0].line, 3);
+      assert.strictEqual(extendsStyleConfigResult[0].column, 1);
+      assert.strictEqual(extendsStyleConfigResult[0].endLine, 3);
+      assert.strictEqual(extendsStyleConfigResult[0].endColumn, 4);
+      assert.strictEqual(
+        extendsStyleConfigResult[1].ruleId,
+        'markdown/no-unused-definitions',
+      );
+      assert.strictEqual(extendsStyleConfigResult[1].severity, 2);
+      assert.strictEqual(extendsStyleConfigResult[1].line, 5);
+      assert.strictEqual(extendsStyleConfigResult[1].column, 1);
+      assert.strictEqual(extendsStyleConfigResult[1].endLine, 5);
+      assert.strictEqual(extendsStyleConfigResult[1].endColumn, 11);
     });
 
     it('Mixed configuration', () => {
@@ -340,28 +351,31 @@ describe('index', () => {
         },
       );
 
-      strictEqual(extendsStyleConfigResult.length, 3);
-      strictEqual(extendsStyleConfigResult[0].ruleId, 'md/no-double-space');
-      strictEqual(extendsStyleConfigResult[0].severity, 2);
-      strictEqual(extendsStyleConfigResult[0].line, 1);
-      strictEqual(extendsStyleConfigResult[0].column, 3);
-      strictEqual(extendsStyleConfigResult[0].endLine, 1);
-      strictEqual(extendsStyleConfigResult[0].endColumn, 5);
-      strictEqual(
+      assert.strictEqual(extendsStyleConfigResult.length, 3);
+      assert.strictEqual(extendsStyleConfigResult[0].ruleId, 'md/no-double-space');
+      assert.strictEqual(extendsStyleConfigResult[0].severity, 2);
+      assert.strictEqual(extendsStyleConfigResult[0].line, 1);
+      assert.strictEqual(extendsStyleConfigResult[0].column, 3);
+      assert.strictEqual(extendsStyleConfigResult[0].endLine, 1);
+      assert.strictEqual(extendsStyleConfigResult[0].endColumn, 5);
+      assert.strictEqual(
         extendsStyleConfigResult[1].ruleId,
         'md/consistent-thematic-break-style',
       );
-      strictEqual(extendsStyleConfigResult[1].severity, 2);
-      strictEqual(extendsStyleConfigResult[1].line, 5);
-      strictEqual(extendsStyleConfigResult[1].column, 1);
-      strictEqual(extendsStyleConfigResult[1].endLine, 5);
-      strictEqual(extendsStyleConfigResult[1].endColumn, 4);
-      strictEqual(extendsStyleConfigResult[2].ruleId, 'markdown/no-unused-definitions');
-      strictEqual(extendsStyleConfigResult[2].severity, 2);
-      strictEqual(extendsStyleConfigResult[2].line, 7);
-      strictEqual(extendsStyleConfigResult[2].column, 1);
-      strictEqual(extendsStyleConfigResult[2].endLine, 7);
-      strictEqual(extendsStyleConfigResult[2].endColumn, 11);
+      assert.strictEqual(extendsStyleConfigResult[1].severity, 2);
+      assert.strictEqual(extendsStyleConfigResult[1].line, 5);
+      assert.strictEqual(extendsStyleConfigResult[1].column, 1);
+      assert.strictEqual(extendsStyleConfigResult[1].endLine, 5);
+      assert.strictEqual(extendsStyleConfigResult[1].endColumn, 4);
+      assert.strictEqual(
+        extendsStyleConfigResult[2].ruleId,
+        'markdown/no-unused-definitions',
+      );
+      assert.strictEqual(extendsStyleConfigResult[2].severity, 2);
+      assert.strictEqual(extendsStyleConfigResult[2].line, 7);
+      assert.strictEqual(extendsStyleConfigResult[2].column, 1);
+      assert.strictEqual(extendsStyleConfigResult[2].endLine, 7);
+      assert.strictEqual(extendsStyleConfigResult[2].endColumn, 11);
     });
   });
 
@@ -373,13 +387,13 @@ describe('index', () => {
         filename: 'test.md',
       });
 
-      strictEqual(cascadingStyleConfigResult.length, 1);
-      strictEqual(cascadingStyleConfigResult[0].ruleId, 'md/no-double-space');
-      strictEqual(cascadingStyleConfigResult[0].severity, 2);
-      strictEqual(cascadingStyleConfigResult[0].line, 1);
-      strictEqual(cascadingStyleConfigResult[0].column, 3);
-      strictEqual(cascadingStyleConfigResult[0].endLine, 1);
-      strictEqual(cascadingStyleConfigResult[0].endColumn, 5);
+      assert.strictEqual(cascadingStyleConfigResult.length, 1);
+      assert.strictEqual(cascadingStyleConfigResult[0].ruleId, 'md/no-double-space');
+      assert.strictEqual(cascadingStyleConfigResult[0].severity, 2);
+      assert.strictEqual(cascadingStyleConfigResult[0].line, 1);
+      assert.strictEqual(cascadingStyleConfigResult[0].column, 3);
+      assert.strictEqual(cascadingStyleConfigResult[0].endLine, 1);
+      assert.strictEqual(cascadingStyleConfigResult[0].endColumn, 5);
     });
 
     it('`all` configuration with `@eslint/markdown` plugin', () => {
@@ -396,19 +410,22 @@ describe('index', () => {
         },
       );
 
-      strictEqual(cascadingStyleConfigResult.length, 2);
-      strictEqual(cascadingStyleConfigResult[0].ruleId, 'md/no-double-space');
-      strictEqual(cascadingStyleConfigResult[0].severity, 2);
-      strictEqual(cascadingStyleConfigResult[0].line, 1);
-      strictEqual(cascadingStyleConfigResult[0].column, 3);
-      strictEqual(cascadingStyleConfigResult[0].endLine, 1);
-      strictEqual(cascadingStyleConfigResult[0].endColumn, 5);
-      strictEqual(cascadingStyleConfigResult[1].ruleId, 'markdown/no-unused-definitions');
-      strictEqual(cascadingStyleConfigResult[1].severity, 2);
-      strictEqual(cascadingStyleConfigResult[1].line, 3);
-      strictEqual(cascadingStyleConfigResult[1].column, 1);
-      strictEqual(cascadingStyleConfigResult[1].endLine, 3);
-      strictEqual(cascadingStyleConfigResult[1].endColumn, 11);
+      assert.strictEqual(cascadingStyleConfigResult.length, 2);
+      assert.strictEqual(cascadingStyleConfigResult[0].ruleId, 'md/no-double-space');
+      assert.strictEqual(cascadingStyleConfigResult[0].severity, 2);
+      assert.strictEqual(cascadingStyleConfigResult[0].line, 1);
+      assert.strictEqual(cascadingStyleConfigResult[0].column, 3);
+      assert.strictEqual(cascadingStyleConfigResult[0].endLine, 1);
+      assert.strictEqual(cascadingStyleConfigResult[0].endColumn, 5);
+      assert.strictEqual(
+        cascadingStyleConfigResult[1].ruleId,
+        'markdown/no-unused-definitions',
+      );
+      assert.strictEqual(cascadingStyleConfigResult[1].severity, 2);
+      assert.strictEqual(cascadingStyleConfigResult[1].line, 3);
+      assert.strictEqual(cascadingStyleConfigResult[1].column, 1);
+      assert.strictEqual(cascadingStyleConfigResult[1].endLine, 3);
+      assert.strictEqual(cascadingStyleConfigResult[1].endColumn, 11);
     });
 
     it('`base` configuration', () => {
@@ -421,13 +438,13 @@ describe('index', () => {
         filename: 'test.md',
       });
 
-      strictEqual(cascadingStyleConfigResult.length, 1);
-      strictEqual(cascadingStyleConfigResult[0].ruleId, 'md/no-double-space');
-      strictEqual(cascadingStyleConfigResult[0].severity, 2);
-      strictEqual(cascadingStyleConfigResult[0].line, 1);
-      strictEqual(cascadingStyleConfigResult[0].column, 3);
-      strictEqual(cascadingStyleConfigResult[0].endLine, 1);
-      strictEqual(cascadingStyleConfigResult[0].endColumn, 5);
+      assert.strictEqual(cascadingStyleConfigResult.length, 1);
+      assert.strictEqual(cascadingStyleConfigResult[0].ruleId, 'md/no-double-space');
+      assert.strictEqual(cascadingStyleConfigResult[0].severity, 2);
+      assert.strictEqual(cascadingStyleConfigResult[0].line, 1);
+      assert.strictEqual(cascadingStyleConfigResult[0].column, 3);
+      assert.strictEqual(cascadingStyleConfigResult[0].endLine, 1);
+      assert.strictEqual(cascadingStyleConfigResult[0].endColumn, 5);
     });
 
     it('`base` configuration with `@eslint/markdown` plugin', () => {
@@ -445,19 +462,22 @@ describe('index', () => {
         },
       );
 
-      strictEqual(cascadingStyleConfigResult.length, 2);
-      strictEqual(cascadingStyleConfigResult[0].ruleId, 'md/no-double-space');
-      strictEqual(cascadingStyleConfigResult[0].severity, 2);
-      strictEqual(cascadingStyleConfigResult[0].line, 1);
-      strictEqual(cascadingStyleConfigResult[0].column, 3);
-      strictEqual(cascadingStyleConfigResult[0].endLine, 1);
-      strictEqual(cascadingStyleConfigResult[0].endColumn, 5);
-      strictEqual(cascadingStyleConfigResult[1].ruleId, 'markdown/no-unused-definitions');
-      strictEqual(cascadingStyleConfigResult[1].severity, 2);
-      strictEqual(cascadingStyleConfigResult[1].line, 3);
-      strictEqual(cascadingStyleConfigResult[1].column, 1);
-      strictEqual(cascadingStyleConfigResult[1].endLine, 3);
-      strictEqual(cascadingStyleConfigResult[1].endColumn, 11);
+      assert.strictEqual(cascadingStyleConfigResult.length, 2);
+      assert.strictEqual(cascadingStyleConfigResult[0].ruleId, 'md/no-double-space');
+      assert.strictEqual(cascadingStyleConfigResult[0].severity, 2);
+      assert.strictEqual(cascadingStyleConfigResult[0].line, 1);
+      assert.strictEqual(cascadingStyleConfigResult[0].column, 3);
+      assert.strictEqual(cascadingStyleConfigResult[0].endLine, 1);
+      assert.strictEqual(cascadingStyleConfigResult[0].endColumn, 5);
+      assert.strictEqual(
+        cascadingStyleConfigResult[1].ruleId,
+        'markdown/no-unused-definitions',
+      );
+      assert.strictEqual(cascadingStyleConfigResult[1].severity, 2);
+      assert.strictEqual(cascadingStyleConfigResult[1].line, 3);
+      assert.strictEqual(cascadingStyleConfigResult[1].column, 1);
+      assert.strictEqual(cascadingStyleConfigResult[1].endLine, 3);
+      assert.strictEqual(cascadingStyleConfigResult[1].endColumn, 11);
     });
 
     it('`recommended` configuration', () => {
@@ -467,13 +487,13 @@ describe('index', () => {
         filename: 'test.md',
       });
 
-      strictEqual(cascadingStyleConfigResult.length, 1);
-      strictEqual(cascadingStyleConfigResult[0].ruleId, 'md/no-double-space');
-      strictEqual(cascadingStyleConfigResult[0].severity, 2);
-      strictEqual(cascadingStyleConfigResult[0].line, 1);
-      strictEqual(cascadingStyleConfigResult[0].column, 3);
-      strictEqual(cascadingStyleConfigResult[0].endLine, 1);
-      strictEqual(cascadingStyleConfigResult[0].endColumn, 5);
+      assert.strictEqual(cascadingStyleConfigResult.length, 1);
+      assert.strictEqual(cascadingStyleConfigResult[0].ruleId, 'md/no-double-space');
+      assert.strictEqual(cascadingStyleConfigResult[0].severity, 2);
+      assert.strictEqual(cascadingStyleConfigResult[0].line, 1);
+      assert.strictEqual(cascadingStyleConfigResult[0].column, 3);
+      assert.strictEqual(cascadingStyleConfigResult[0].endLine, 1);
+      assert.strictEqual(cascadingStyleConfigResult[0].endColumn, 5);
     });
 
     it('`recommended` configuration with `@eslint/markdown` plugin', () => {
@@ -490,19 +510,22 @@ describe('index', () => {
         },
       );
 
-      strictEqual(cascadingStyleConfigResult.length, 2);
-      strictEqual(cascadingStyleConfigResult[0].ruleId, 'md/no-double-space');
-      strictEqual(cascadingStyleConfigResult[0].severity, 2);
-      strictEqual(cascadingStyleConfigResult[0].line, 1);
-      strictEqual(cascadingStyleConfigResult[0].column, 3);
-      strictEqual(cascadingStyleConfigResult[0].endLine, 1);
-      strictEqual(cascadingStyleConfigResult[0].endColumn, 5);
-      strictEqual(cascadingStyleConfigResult[1].ruleId, 'markdown/no-unused-definitions');
-      strictEqual(cascadingStyleConfigResult[1].severity, 2);
-      strictEqual(cascadingStyleConfigResult[1].line, 3);
-      strictEqual(cascadingStyleConfigResult[1].column, 1);
-      strictEqual(cascadingStyleConfigResult[1].endLine, 3);
-      strictEqual(cascadingStyleConfigResult[1].endColumn, 11);
+      assert.strictEqual(cascadingStyleConfigResult.length, 2);
+      assert.strictEqual(cascadingStyleConfigResult[0].ruleId, 'md/no-double-space');
+      assert.strictEqual(cascadingStyleConfigResult[0].severity, 2);
+      assert.strictEqual(cascadingStyleConfigResult[0].line, 1);
+      assert.strictEqual(cascadingStyleConfigResult[0].column, 3);
+      assert.strictEqual(cascadingStyleConfigResult[0].endLine, 1);
+      assert.strictEqual(cascadingStyleConfigResult[0].endColumn, 5);
+      assert.strictEqual(
+        cascadingStyleConfigResult[1].ruleId,
+        'markdown/no-unused-definitions',
+      );
+      assert.strictEqual(cascadingStyleConfigResult[1].severity, 2);
+      assert.strictEqual(cascadingStyleConfigResult[1].line, 3);
+      assert.strictEqual(cascadingStyleConfigResult[1].column, 1);
+      assert.strictEqual(cascadingStyleConfigResult[1].endLine, 3);
+      assert.strictEqual(cascadingStyleConfigResult[1].endColumn, 11);
     });
 
     it('`stylistic` configuration', () => {
@@ -516,16 +539,16 @@ describe('index', () => {
         },
       );
 
-      strictEqual(cascadingStyleConfigResult.length, 1);
-      strictEqual(
+      assert.strictEqual(cascadingStyleConfigResult.length, 1);
+      assert.strictEqual(
         cascadingStyleConfigResult[0].ruleId,
         'md/consistent-thematic-break-style',
       );
-      strictEqual(cascadingStyleConfigResult[0].severity, 2);
-      strictEqual(cascadingStyleConfigResult[0].line, 3);
-      strictEqual(cascadingStyleConfigResult[0].column, 1);
-      strictEqual(cascadingStyleConfigResult[0].endLine, 3);
-      strictEqual(cascadingStyleConfigResult[0].endColumn, 4);
+      assert.strictEqual(cascadingStyleConfigResult[0].severity, 2);
+      assert.strictEqual(cascadingStyleConfigResult[0].line, 3);
+      assert.strictEqual(cascadingStyleConfigResult[0].column, 1);
+      assert.strictEqual(cascadingStyleConfigResult[0].endLine, 3);
+      assert.strictEqual(cascadingStyleConfigResult[0].endColumn, 4);
     });
 
     it('`stylistic` configuration with `@eslint/markdown` plugin', () => {
@@ -542,22 +565,25 @@ describe('index', () => {
         },
       );
 
-      strictEqual(cascadingStyleConfigResult.length, 2);
-      strictEqual(
+      assert.strictEqual(cascadingStyleConfigResult.length, 2);
+      assert.strictEqual(
         cascadingStyleConfigResult[0].ruleId,
         'md/consistent-thematic-break-style',
       );
-      strictEqual(cascadingStyleConfigResult[0].severity, 2);
-      strictEqual(cascadingStyleConfigResult[0].line, 3);
-      strictEqual(cascadingStyleConfigResult[0].column, 1);
-      strictEqual(cascadingStyleConfigResult[0].endLine, 3);
-      strictEqual(cascadingStyleConfigResult[0].endColumn, 4);
-      strictEqual(cascadingStyleConfigResult[1].ruleId, 'markdown/no-unused-definitions');
-      strictEqual(cascadingStyleConfigResult[1].severity, 2);
-      strictEqual(cascadingStyleConfigResult[1].line, 5);
-      strictEqual(cascadingStyleConfigResult[1].column, 1);
-      strictEqual(cascadingStyleConfigResult[1].endLine, 5);
-      strictEqual(cascadingStyleConfigResult[1].endColumn, 11);
+      assert.strictEqual(cascadingStyleConfigResult[0].severity, 2);
+      assert.strictEqual(cascadingStyleConfigResult[0].line, 3);
+      assert.strictEqual(cascadingStyleConfigResult[0].column, 1);
+      assert.strictEqual(cascadingStyleConfigResult[0].endLine, 3);
+      assert.strictEqual(cascadingStyleConfigResult[0].endColumn, 4);
+      assert.strictEqual(
+        cascadingStyleConfigResult[1].ruleId,
+        'markdown/no-unused-definitions',
+      );
+      assert.strictEqual(cascadingStyleConfigResult[1].severity, 2);
+      assert.strictEqual(cascadingStyleConfigResult[1].line, 5);
+      assert.strictEqual(cascadingStyleConfigResult[1].column, 1);
+      assert.strictEqual(cascadingStyleConfigResult[1].endLine, 5);
+      assert.strictEqual(cascadingStyleConfigResult[1].endColumn, 11);
     });
 
     it('Mixed configuration', () => {
@@ -575,28 +601,31 @@ describe('index', () => {
         },
       );
 
-      strictEqual(cascadingStyleConfigResult.length, 3);
-      strictEqual(cascadingStyleConfigResult[0].ruleId, 'md/no-double-space');
-      strictEqual(cascadingStyleConfigResult[0].severity, 2);
-      strictEqual(cascadingStyleConfigResult[0].line, 1);
-      strictEqual(cascadingStyleConfigResult[0].column, 3);
-      strictEqual(cascadingStyleConfigResult[0].endLine, 1);
-      strictEqual(cascadingStyleConfigResult[0].endColumn, 5);
-      strictEqual(
+      assert.strictEqual(cascadingStyleConfigResult.length, 3);
+      assert.strictEqual(cascadingStyleConfigResult[0].ruleId, 'md/no-double-space');
+      assert.strictEqual(cascadingStyleConfigResult[0].severity, 2);
+      assert.strictEqual(cascadingStyleConfigResult[0].line, 1);
+      assert.strictEqual(cascadingStyleConfigResult[0].column, 3);
+      assert.strictEqual(cascadingStyleConfigResult[0].endLine, 1);
+      assert.strictEqual(cascadingStyleConfigResult[0].endColumn, 5);
+      assert.strictEqual(
         cascadingStyleConfigResult[1].ruleId,
         'md/consistent-thematic-break-style',
       );
-      strictEqual(cascadingStyleConfigResult[1].severity, 2);
-      strictEqual(cascadingStyleConfigResult[1].line, 5);
-      strictEqual(cascadingStyleConfigResult[1].column, 1);
-      strictEqual(cascadingStyleConfigResult[1].endLine, 5);
-      strictEqual(cascadingStyleConfigResult[1].endColumn, 4);
-      strictEqual(cascadingStyleConfigResult[2].ruleId, 'markdown/no-unused-definitions');
-      strictEqual(cascadingStyleConfigResult[2].severity, 2);
-      strictEqual(cascadingStyleConfigResult[2].line, 7);
-      strictEqual(cascadingStyleConfigResult[2].column, 1);
-      strictEqual(cascadingStyleConfigResult[2].endLine, 7);
-      strictEqual(cascadingStyleConfigResult[2].endColumn, 11);
+      assert.strictEqual(cascadingStyleConfigResult[1].severity, 2);
+      assert.strictEqual(cascadingStyleConfigResult[1].line, 5);
+      assert.strictEqual(cascadingStyleConfigResult[1].column, 1);
+      assert.strictEqual(cascadingStyleConfigResult[1].endLine, 5);
+      assert.strictEqual(cascadingStyleConfigResult[1].endColumn, 4);
+      assert.strictEqual(
+        cascadingStyleConfigResult[2].ruleId,
+        'markdown/no-unused-definitions',
+      );
+      assert.strictEqual(cascadingStyleConfigResult[2].severity, 2);
+      assert.strictEqual(cascadingStyleConfigResult[2].line, 7);
+      assert.strictEqual(cascadingStyleConfigResult[2].column, 1);
+      assert.strictEqual(cascadingStyleConfigResult[2].endLine, 7);
+      assert.strictEqual(cascadingStyleConfigResult[2].endColumn, 11);
     });
   });
 });

--- a/packages/eslint-markdown/src/tests/rule-tester.ts
+++ b/packages/eslint-markdown/src/tests/rule-tester.ts
@@ -6,8 +6,7 @@
 // Import
 // --------------------------------------------------------------------------------
 
-import { describe, it } from 'vitest';
-import { match, ok } from 'node:assert';
+import { assert, describe, it } from 'vitest';
 import { RuleTester } from 'eslint';
 import markdown, { type MarkdownRuleDefinitionTypeOptions } from '@eslint/markdown';
 import type { RuleModule } from '../core/types.js';
@@ -67,49 +66,49 @@ export default function ruleTester(
   describe(ruleName, () => {
     describe('meta', () => {
       it('`meta` should exist', () => {
-        ok(meta);
+        assert.ok(meta);
       });
 
       it('`meta.type` should exist', () => {
-        ok(meta?.type);
+        assert.ok(meta?.type);
       });
 
       it('`meta.docs` should exist', () => {
-        ok(meta?.docs);
+        assert.ok(meta?.docs);
       });
 
       it('`meta.docs.description` should exist and follow the convention', () => {
-        ok(meta?.docs?.description);
-        match(meta?.docs?.description, /^(?:Enforce|Require|Disallow) .+[^. ]$/);
+        assert.ok(meta?.docs?.description);
+        assert.match(meta?.docs?.description, /^(?:Enforce|Require|Disallow) .+[^. ]$/);
       });
 
       it('`meta.docs.url` should exist and end with the rule name', () => {
-        ok(meta?.docs?.url);
-        match(meta?.docs?.url, new RegExp(`${ruleName}$`));
+        assert.ok(meta?.docs?.url);
+        assert.match(meta?.docs?.url, new RegExp(`${ruleName}$`));
       });
 
       it('`meta.messages` should exist', () => {
-        ok(meta?.messages);
+        assert.ok(meta?.messages);
       });
 
       it('`meta.messages.messageId` should exist and value should follow the convention', () => {
         // @ts-expect-error -- Required for testing.
         Object.values(meta.messages).forEach(message => {
-          ok(message);
-          match(message, /^[^a-z].*\.$/);
+          assert.ok(message);
+          assert.match(message, /^[^a-z].*\.$/);
         });
       });
 
       it("`meta.language` should exist and be `'markdown'`", () => {
-        ok(meta?.language);
-        match(meta?.language, /^markdown$/);
+        assert.ok(meta?.language);
+        assert.match(meta?.language, /^markdown$/);
       });
 
       it("`meta.dialects` should exist and be `'commonmark'` or `'gfm'`", () => {
-        ok(meta?.dialects);
-        ok(meta?.dialects.length > 0);
+        assert.ok(meta?.dialects);
+        assert.ok(meta?.dialects.length > 0);
         meta?.dialects.forEach(dialect => {
-          match(dialect, /^(?:commonmark|gfm)$/);
+          assert.match(dialect, /^(?:commonmark|gfm)$/);
         });
       });
     });


### PR DESCRIPTION
This pull request refactors the test files in the `eslint-markdown` package to use the `assert` API from `vitest` instead of Node's built-in `assert` module. This change standardizes the assertion library across the test suite, ensuring consistency and better integration with `vitest`.

**Test code refactoring:**

* Replaced imports of Node's `assert` methods (`ok`, `strictEqual`, `match`) with the `assert` API from `vitest` in all test files, including `escape-string-regexp.test.ts`, `html.test.ts`, `is-blank-line.test.ts`, `skip-ranges.test.ts`, and `rule-tester.ts`. [[1]](diffhunk://#diff-18b776d5cfab2b25737b10122733e8257b0cb29ce2ed06d5d88b3ef33007dbaaL34-R34) [[2]](diffhunk://#diff-297950703fb44ee9fbb108aa05a85f5b7737f18973455c825f4a726fcd508af4L9-R9) [[3]](diffhunk://#diff-6f155ae0f863fc7bfd1ae413218a61b247d7c8bff655c57123c322d3bd7ec660L9-R9) [[4]](diffhunk://#diff-f9a745b9e5e0a4c1355c9c2a9ce159a38a2a6962144fb6266411c6957a988f86L13-R13) [[5]](diffhunk://#diff-4de424531d3f132c79334105209b201cf87c773cca09d725ed45a54f34e3870bL9-R9)
* Updated all assertion calls to use `assert.strictEqual`, `assert.ok`, and `assert.match` as appropriate throughout the affected test files. [[1]](diffhunk://#diff-18b776d5cfab2b25737b10122733e8257b0cb29ce2ed06d5d88b3ef33007dbaaL44-R54) [[2]](diffhunk://#diff-297950703fb44ee9fbb108aa05a85f5b7737f18973455c825f4a726fcd508af4L27-R33) [[3]](diffhunk://#diff-6f155ae0f863fc7bfd1ae413218a61b247d7c8bff655c57123c322d3bd7ec660L20-R93) [[4]](diffhunk://#diff-f9a745b9e5e0a4c1355c9c2a9ce159a38a2a6962144fb6266411c6957a988f86L38-R70) [[5]](diffhunk://#diff-f9a745b9e5e0a4c1355c9c2a9ce159a38a2a6962144fb6266411c6957a988f86L81-R89) [[6]](diffhunk://#diff-f9a745b9e5e0a4c1355c9c2a9ce159a38a2a6962144fb6266411c6957a988f86L100-R109) [[7]](diffhunk://#diff-f9a745b9e5e0a4c1355c9c2a9ce159a38a2a6962144fb6266411c6957a988f86L120-R131) [[8]](diffhunk://#diff-4de424531d3f132c79334105209b201cf87c773cca09d725ed45a54f34e3870bL70-R111)