### PR TITLE
chore(release): bump package versions from `v0.11.1` to `v0.12.0` (`minor`)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "npm-eslint-markdown",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "npm-eslint-markdown",
-      "version": "0.11.1",
+      "version": "0.12.0",
       "workspaces": [
         "packages/*",
         "website"
@@ -9966,7 +9966,7 @@
       }
     },
     "packages/eslint-markdown": {
-      "version": "0.11.1",
+      "version": "0.12.0",
       "license": "MIT",
       "dependencies": {
         "@eslint/markdown": "^7.5.1",
@@ -10006,7 +10006,7 @@
         "@codecov/bundler-plugin-core": "^2.0.1",
         "@shikijs/transformers": "^3.20.0",
         "@shikijs/vitepress-twoslash": "^3.20.0",
-        "eslint-markdown": "^0.11.1",
+        "eslint-markdown": "^0.12.0",
         "twoslash-eslint": "^0.3.4",
         "unplugin": "^1.16.1",
         "vitepress": "2.0.0-alpha.17",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "npm-eslint-markdown",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "type": "module",
   "packageManager": "npm@10.9.2",
   "engines": {

--- a/packages/eslint-markdown/package.json
+++ b/packages/eslint-markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-markdown",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "type": "module",
   "sideEffects": false,
   "description": "Lint your Markdown with ESLint. Additional rules for use with `@eslint/markdown`.🛠️",

--- a/website/package.json
+++ b/website/package.json
@@ -11,7 +11,7 @@
     "@codecov/bundler-plugin-core": "^2.0.1",
     "@shikijs/transformers": "^3.20.0",
     "@shikijs/vitepress-twoslash": "^3.20.0",
-    "eslint-markdown": "^0.11.1",
+    "eslint-markdown": "^0.12.0",
     "twoslash-eslint": "^0.3.4",
     "unplugin": "^1.16.1",
     "vitepress": "2.0.0-alpha.17",


### PR DESCRIPTION
## Release Information: `v0.12.0`

New release of `lumirlumir/npm-eslint-markdown` has arrived! :tada:

This PR bumps the package versions from `v0.11.1` to `v0.12.0` (`minor`).

See [Actions](https://github.com/lumirlumir/npm-eslint-markdown/actions/runs/28932258970) for more details.

| Info        | Value                      |
| ----------- | -------------------------- |
| Repository  | `lumirlumir/npm-eslint-markdown` |
| SEMVER      | `minor`     |
| Pre ID      | `canary`      |
| Short SHA   | 7d8f522       |
| Old Version | `v0.11.1`  |
| New Version | `v0.12.0`  |

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### :sparkles: Features
* feat(eslint-markdown): add `allow-heading` rule by @lumirlumir in https://github.com/lumirlumir/npm-eslint-markdown/pull/611
### :toolbox: Chores
* chore(website): replace codecov vite plugin for vite 7 by @lumirlumir in https://github.com/lumirlumir/npm-eslint-markdown/pull/607
### :recycle: Code Refactoring
* refactor(eslint-markdown): rename `core/ast` directory to `core/utils` by @lumirlumir in https://github.com/lumirlumir/npm-eslint-markdown/pull/610
### :test_tube: Tests
* test(eslint-markdown): replace node assert with vitest assert by @lumirlumir in https://github.com/lumirlumir/npm-eslint-markdown/pull/612


**Full Changelog**: https://github.com/lumirlumir/npm-eslint-markdown/compare/v0.11.1...v0.12.0