### PR TITLE
fix(eslint-markdown): handle stateful regex for `allow-image-url`

### DIFF
--- a/packages/eslint-markdown/src/rules/allow-image-url.test.ts
+++ b/packages/eslint-markdown/src/rules/allow-image-url.test.ts
@@ -217,6 +217,26 @@ ruleTester('allow-image-url', rule, {
         },
       ],
     },
+
+    // Edge cases
+    {
+      name: '`allowUrls` should allow repeated image URLs with global pattern',
+      code: '![Text](https://example.com)\n![Text](https://example.com)',
+      options: [
+        {
+          allowUrls: [/^https:\/\/example\.com$/g],
+        },
+      ],
+    },
+    {
+      name: '`allowUrls` should allow repeated image URLs with sticky pattern',
+      code: '![Text](https://example.com)\n![Text](https://example.com)',
+      options: [
+        {
+          allowUrls: [/^https:\/\/example\.com$/y],
+        },
+      ],
+    },
   ],
 
   invalid: [
@@ -535,6 +555,72 @@ ruleTester('allow-image-url', rule, {
           line: 8,
           column: 1,
           endLine: 8,
+          endColumn: 29,
+        },
+      ],
+    },
+    {
+      name: '`disallowUrls` should report repeated image URLs with global pattern',
+      code: '![Text](https://example.com)\n![Text](https://example.com)',
+      options: [
+        {
+          disallowUrls: [/^https:\/\/example\.com$/g],
+        },
+      ],
+      errors: [
+        {
+          messageId: 'disallowImageUrl',
+          data: {
+            url: 'https://example.com',
+            patterns: '`/^https:\\/\\/example\\.com$/g`',
+          },
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 29,
+        },
+        {
+          messageId: 'disallowImageUrl',
+          data: {
+            url: 'https://example.com',
+            patterns: '`/^https:\\/\\/example\\.com$/g`',
+          },
+          line: 2,
+          column: 1,
+          endLine: 2,
+          endColumn: 29,
+        },
+      ],
+    },
+    {
+      name: '`disallowUrls` should report repeated image URLs with sticky pattern',
+      code: '![Text](https://example.com)\n![Text](https://example.com)',
+      options: [
+        {
+          disallowUrls: [/^https:\/\/example\.com$/y],
+        },
+      ],
+      errors: [
+        {
+          messageId: 'disallowImageUrl',
+          data: {
+            url: 'https://example.com',
+            patterns: '`/^https:\\/\\/example\\.com$/y`',
+          },
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 29,
+        },
+        {
+          messageId: 'disallowImageUrl',
+          data: {
+            url: 'https://example.com',
+            patterns: '`/^https:\\/\\/example\\.com$/y`',
+          },
+          line: 2,
+          column: 1,
+          endLine: 2,
           endColumn: 29,
         },
       ],

--- a/packages/eslint-markdown/src/rules/allow-image-url.ts
+++ b/packages/eslint-markdown/src/rules/allow-image-url.ts
@@ -24,6 +24,24 @@ type RuleOptions = [
 type MessageIds = 'allowImageUrl' | 'disallowImageUrl';
 
 // --------------------------------------------------------------------------------
+// Helper
+// --------------------------------------------------------------------------------
+
+const statefulRegexFlagRegex = /[gy]/u;
+
+/**
+ * Tests a regex without mutating the state stored in its `lastIndex`.
+ * @param regex Regex to test.
+ * @param text Text to test.
+ * @returns Whether the regex matches the text.
+ */
+function testRegexStateless(regex: RegExp, text: string) {
+  return statefulRegexFlagRegex.test(regex.flags)
+    ? new RegExp(regex).test(text)
+    : regex.test(text);
+}
+
+// --------------------------------------------------------------------------------
 // Rule Definition
 // --------------------------------------------------------------------------------
 
@@ -159,7 +177,7 @@ export default {
          */
 
         for (const { loc, url } of images) {
-          if (!allowUrls.some(regex => regex.test(url))) {
+          if (!allowUrls.some(regex => testRegexStateless(regex, url))) {
             context.report({
               loc,
               messageId: 'allowImageUrl',
@@ -170,7 +188,7 @@ export default {
             });
           }
 
-          if (disallowUrls.some(regex => regex.test(url))) {
+          if (disallowUrls.some(regex => testRegexStateless(regex, url))) {
             context.report({
               loc,
               messageId: 'disallowImageUrl',


### PR DESCRIPTION
This pull request improves the handling of regular expressions with the global (`g`) and sticky (`y`) flags in the `allow-image-url` ESLint rule to ensure they are tested in a stateless way. It also adds comprehensive test cases to cover these scenarios.

Enhancements to regex handling:

* Added a helper function `testRegexStateless` in `allow-image-url.ts` to test regexes without mutating their internal state, preventing issues with repeated matches when using global or sticky flags.
* Updated the rule logic to use `testRegexStateless` for both `allowUrls` and `disallowUrls` checks, ensuring consistent behavior regardless of regex flags. [[1]](diffhunk://#diff-f0c45d42ca398155c9a8668f98a6f2403e937f915f61bad1dc4582aa2714996bL162-R180) [[2]](diffhunk://#diff-f0c45d42ca398155c9a8668f98a6f2403e937f915f61bad1dc4582aa2714996bL173-R191)

Expanded test coverage:

* Added tests to `allow-image-url.test.ts` to verify that repeated image URLs are correctly allowed or disallowed when using global or sticky regex patterns in both `allowUrls` and `disallowUrls` options. [[1]](diffhunk://#diff-dcebd9d88de4aac781e035c6e94e971ef40179680092c4b4bcc02b2849680886R220-R239) [[2]](diffhunk://#diff-dcebd9d88de4aac781e035c6e94e971ef40179680092c4b4bcc02b2849680886R562-R627)