### PR TITLE
fix(eslint-markdown): handle stateful regex for `allow-link-url`

### DIFF
--- a/packages/eslint-markdown/src/rules/allow-link-url.test.ts
+++ b/packages/eslint-markdown/src/rules/allow-link-url.test.ts
@@ -226,6 +226,26 @@ ruleTester('allow-link-url', rule, {
         },
       ],
     },
+
+    // Edge cases
+    {
+      name: '`allowUrls` should allow repeated link URLs with global pattern',
+      code: '[Text](https://example.com)\n[Text](https://example.com)',
+      options: [
+        {
+          allowUrls: [/^https:\/\/example\.com$/g],
+        },
+      ],
+    },
+    {
+      name: '`allowUrls` should allow repeated link URLs with sticky pattern',
+      code: '[Text](https://example.com)\n[Text](https://example.com)',
+      options: [
+        {
+          allowUrls: [/^https:\/\/example\.com$/y],
+        },
+      ],
+    },
   ],
 
   invalid: [
@@ -580,6 +600,72 @@ ruleTester('allow-link-url', rule, {
           column: 1,
           endLine: 10,
           endColumn: 29,
+        },
+      ],
+    },
+    {
+      name: '`disallowUrls` should report repeated link URLs with global pattern',
+      code: '[Text](https://example.com)\n[Text](https://example.com)',
+      options: [
+        {
+          disallowUrls: [/^https:\/\/example\.com$/g],
+        },
+      ],
+      errors: [
+        {
+          messageId: 'disallowLinkUrl',
+          data: {
+            url: 'https://example.com',
+            patterns: '`/^https:\\/\\/example\\.com$/g`',
+          },
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 28,
+        },
+        {
+          messageId: 'disallowLinkUrl',
+          data: {
+            url: 'https://example.com',
+            patterns: '`/^https:\\/\\/example\\.com$/g`',
+          },
+          line: 2,
+          column: 1,
+          endLine: 2,
+          endColumn: 28,
+        },
+      ],
+    },
+    {
+      name: '`disallowUrls` should report repeated link URLs with sticky pattern',
+      code: '[Text](https://example.com)\n[Text](https://example.com)',
+      options: [
+        {
+          disallowUrls: [/^https:\/\/example\.com$/y],
+        },
+      ],
+      errors: [
+        {
+          messageId: 'disallowLinkUrl',
+          data: {
+            url: 'https://example.com',
+            patterns: '`/^https:\\/\\/example\\.com$/y`',
+          },
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 28,
+        },
+        {
+          messageId: 'disallowLinkUrl',
+          data: {
+            url: 'https://example.com',
+            patterns: '`/^https:\\/\\/example\\.com$/y`',
+          },
+          line: 2,
+          column: 1,
+          endLine: 2,
+          endColumn: 28,
         },
       ],
     },

--- a/packages/eslint-markdown/src/rules/allow-link-url.ts
+++ b/packages/eslint-markdown/src/rules/allow-link-url.ts
@@ -24,6 +24,24 @@ type RuleOptions = [
 type MessageIds = 'allowLinkUrl' | 'disallowLinkUrl';
 
 // --------------------------------------------------------------------------------
+// Helper
+// --------------------------------------------------------------------------------
+
+const statefulRegexFlagRegex = /[gy]/u;
+
+/**
+ * Tests a regex without mutating the state stored in its `lastIndex`.
+ * @param regex Regex to test.
+ * @param text Text to test.
+ * @returns Whether the regex matches the text.
+ */
+function testRegexStateless(regex: RegExp, text: string) {
+  return statefulRegexFlagRegex.test(regex.flags)
+    ? new RegExp(regex).test(text)
+    : regex.test(text);
+}
+
+// --------------------------------------------------------------------------------
 // Rule Definition
 // --------------------------------------------------------------------------------
 
@@ -159,7 +177,7 @@ export default {
          */
 
         for (const { loc, url } of links) {
-          if (!allowUrls.some(regex => regex.test(url))) {
+          if (!allowUrls.some(regex => testRegexStateless(regex, url))) {
             context.report({
               loc,
               messageId: 'allowLinkUrl',
@@ -170,7 +188,7 @@ export default {
             });
           }
 
-          if (disallowUrls.some(regex => regex.test(url))) {
+          if (disallowUrls.some(regex => testRegexStateless(regex, url))) {
             context.report({
               loc,
               messageId: 'disallowLinkUrl',


### PR DESCRIPTION
This pull request improves the handling of regular expressions with global (`g`) and sticky (`y`) flags in the `allow-link-url` ESLint rule. It ensures that repeated link URLs are correctly matched and reported, regardless of the regex flags used. The changes also add comprehensive test cases to cover these scenarios.

**Regex handling improvements:**

* Introduced the `testRegexStateless` helper function in `allow-link-url.ts` to safely test regexes with `g` or `y` flags without mutating their internal state (`lastIndex`).
* Updated the rule logic to use `testRegexStateless` when checking `allowUrls` and `disallowUrls`, ensuring consistent behavior for repeated matches. [[1]](diffhunk://#diff-c2020f9d6c66e84127343f5ad0efdf7aa23d0f6a81fe52bfe8c738ab37a7bc64L162-R180) [[2]](diffhunk://#diff-c2020f9d6c66e84127343f5ad0efdf7aa23d0f6a81fe52bfe8c738ab37a7bc64L173-R191)

**Test coverage enhancements:**

* Added test cases in `allow-link-url.test.ts` to verify that repeated link URLs are correctly allowed or reported when using global or sticky regex patterns in both `allowUrls` and `disallowUrls` options. [[1]](diffhunk://#diff-6ead70e57495b1a72dd4d01e66813c39bed2124f18f3e89c9577367fa51e5981R229-R248) [[2]](diffhunk://#diff-6ead70e57495b1a72dd4d01e66813c39bed2124f18f3e89c9577367fa51e5981R606-R671)