### PR TITLE
refactor(eslint-markdown): extract stateless regex test utility

### DIFF
--- a/packages/eslint-markdown/src/core/utils/index.ts
+++ b/packages/eslint-markdown/src/core/utils/index.ts
@@ -2,5 +2,12 @@ import escapeStringRegexp from './escape-string-regexp.js';
 import getElementsByTagName from './html.js';
 import isBlankLine from './is-blank-line.js';
 import SkipRanges from './skip-ranges.js';
+import testRegexStateless from './test-regex-stateless.js';
 
-export { escapeStringRegexp, getElementsByTagName, isBlankLine, SkipRanges };
+export {
+  escapeStringRegexp,
+  getElementsByTagName,
+  isBlankLine,
+  SkipRanges,
+  testRegexStateless,
+};

--- a/packages/eslint-markdown/src/core/utils/test-regex-stateless.test.ts
+++ b/packages/eslint-markdown/src/core/utils/test-regex-stateless.test.ts
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Test for `test-regex-stateless.js`
+ * @fileoverview Test for `test-regex-stateless.ts`
  */
 
 // --------------------------------------------------------------------------------

--- a/packages/eslint-markdown/src/core/utils/test-regex-stateless.test.ts
+++ b/packages/eslint-markdown/src/core/utils/test-regex-stateless.test.ts
@@ -1,0 +1,39 @@
+/**
+ * @fileoverview Test for `test-regex-stateless.js`
+ */
+
+// --------------------------------------------------------------------------------
+// Import
+// --------------------------------------------------------------------------------
+
+import { assert, describe, it } from 'vitest';
+import testRegexStateless from './test-regex-stateless.js';
+
+// --------------------------------------------------------------------------------
+// Test
+// --------------------------------------------------------------------------------
+
+describe('test-regex-stateless', () => {
+  it('should test a regex without a stateful flag', () => {
+    assert.strictEqual(testRegexStateless(/allowed/u, 'allowed'), true);
+    assert.strictEqual(testRegexStateless(/allowed/u, 'denied'), false);
+  });
+
+  it('should test a global regex without mutating its `lastIndex`', () => {
+    const regex = /allowed/gu;
+
+    regex.lastIndex = 4;
+
+    assert.strictEqual(testRegexStateless(regex, 'allowed'), true);
+    assert.strictEqual(regex.lastIndex, 4);
+  });
+
+  it('should test a sticky regex without mutating its `lastIndex`', () => {
+    const regex = /allowed/uy;
+
+    regex.lastIndex = 4;
+
+    assert.strictEqual(testRegexStateless(regex, 'allowed'), true);
+    assert.strictEqual(regex.lastIndex, 4);
+  });
+});

--- a/packages/eslint-markdown/src/core/utils/test-regex-stateless.ts
+++ b/packages/eslint-markdown/src/core/utils/test-regex-stateless.ts
@@ -1,0 +1,25 @@
+/**
+ * @fileoverview Utility to test a regular expression without mutating its state.
+ */
+
+// --------------------------------------------------------------------------------
+// Helper
+// --------------------------------------------------------------------------------
+
+const statefulRegexFlagRegex = /[gy]/u;
+
+// --------------------------------------------------------------------------------
+// Export
+// --------------------------------------------------------------------------------
+
+/**
+ * Tests a regex without mutating the state stored in its `lastIndex`.
+ * @param regex Regex to test.
+ * @param text Text to test.
+ * @returns Whether the regex matches the text.
+ */
+export default function testRegexStateless(regex: RegExp, text: string) {
+  return statefulRegexFlagRegex.test(regex.flags)
+    ? new RegExp(regex).test(text)
+    : regex.test(text);
+}

--- a/packages/eslint-markdown/src/rules/allow-heading.ts
+++ b/packages/eslint-markdown/src/rules/allow-heading.ts
@@ -8,9 +8,9 @@
 // --------------------------------------------------------------------------------
 
 import type { Heading } from 'mdast';
+import { testRegexStateless } from '../core/utils/index.js';
 import { URL_RULE_DOCS } from '../core/constants.js';
 import type { RuleModule } from '../core/types.js';
-import { testRegexStateless } from '../core/utils/index.js';
 
 // --------------------------------------------------------------------------------
 // Typedef

--- a/packages/eslint-markdown/src/rules/allow-heading.ts
+++ b/packages/eslint-markdown/src/rules/allow-heading.ts
@@ -10,6 +10,7 @@
 import type { Heading } from 'mdast';
 import { URL_RULE_DOCS } from '../core/constants.js';
 import type { RuleModule } from '../core/types.js';
+import { testRegexStateless } from '../core/utils/index.js';
 
 // --------------------------------------------------------------------------------
 // Typedef
@@ -25,8 +26,6 @@ type MessageIds = 'allowHeading' | 'disallowHeading';
 // --------------------------------------------------------------------------------
 // Helper
 // --------------------------------------------------------------------------------
-
-const statefulRegexFlagRegex = /[gy]/u;
 
 const headingOptionsSchema = {
   type: 'object',
@@ -48,18 +47,6 @@ const headingOptionsSchema = {
   },
   additionalProperties: false,
 } as const;
-
-/**
- * Tests a regex without mutating the state stored in its `lastIndex`.
- * @param regex Regex to test.
- * @param text Text to test.
- * @returns Whether the regex matches the text.
- */
-function testRegexStateless(regex: RegExp, text: string) {
-  return statefulRegexFlagRegex.test(regex.flags)
-    ? new RegExp(regex).test(text)
-    : regex.test(text);
-}
 
 // --------------------------------------------------------------------------------
 // Rule Definition

--- a/packages/eslint-markdown/src/rules/allow-image-url.ts
+++ b/packages/eslint-markdown/src/rules/allow-image-url.ts
@@ -10,7 +10,7 @@
 import type { Definition } from 'mdast';
 import { normalizeIdentifier } from 'micromark-util-normalize-identifier';
 import type { Position } from 'unist';
-import { getElementsByTagName } from '../core/utils/index.js';
+import { getElementsByTagName, testRegexStateless } from '../core/utils/index.js';
 import { URL_RULE_DOCS } from '../core/constants.js';
 import type { RuleModule } from '../core/types.js';
 
@@ -22,24 +22,6 @@ type RuleOptions = [
   { allowUrls: RegExp[]; disallowUrls: RegExp[]; allowDefinitions: string[] },
 ];
 type MessageIds = 'allowImageUrl' | 'disallowImageUrl';
-
-// --------------------------------------------------------------------------------
-// Helper
-// --------------------------------------------------------------------------------
-
-const statefulRegexFlagRegex = /[gy]/u;
-
-/**
- * Tests a regex without mutating the state stored in its `lastIndex`.
- * @param regex Regex to test.
- * @param text Text to test.
- * @returns Whether the regex matches the text.
- */
-function testRegexStateless(regex: RegExp, text: string) {
-  return statefulRegexFlagRegex.test(regex.flags)
-    ? new RegExp(regex).test(text)
-    : regex.test(text);
-}
 
 // --------------------------------------------------------------------------------
 // Rule Definition

--- a/packages/eslint-markdown/src/rules/allow-link-url.ts
+++ b/packages/eslint-markdown/src/rules/allow-link-url.ts
@@ -10,7 +10,7 @@
 import type { Definition } from 'mdast';
 import { normalizeIdentifier } from 'micromark-util-normalize-identifier';
 import type { Position } from 'unist';
-import { getElementsByTagName } from '../core/utils/index.js';
+import { getElementsByTagName, testRegexStateless } from '../core/utils/index.js';
 import { URL_RULE_DOCS } from '../core/constants.js';
 import type { RuleModule } from '../core/types.js';
 
@@ -22,24 +22,6 @@ type RuleOptions = [
   { allowUrls: RegExp[]; disallowUrls: RegExp[]; allowDefinitions: string[] },
 ];
 type MessageIds = 'allowLinkUrl' | 'disallowLinkUrl';
-
-// --------------------------------------------------------------------------------
-// Helper
-// --------------------------------------------------------------------------------
-
-const statefulRegexFlagRegex = /[gy]/u;
-
-/**
- * Tests a regex without mutating the state stored in its `lastIndex`.
- * @param regex Regex to test.
- * @param text Text to test.
- * @returns Whether the regex matches the text.
- */
-function testRegexStateless(regex: RegExp, text: string) {
-  return statefulRegexFlagRegex.test(regex.flags)
-    ? new RegExp(regex).test(text)
-    : regex.test(text);
-}
 
 // --------------------------------------------------------------------------------
 // Rule Definition


### PR DESCRIPTION
This pull request refactors how the `testRegexStateless` utility is shared and used across the codebase. The main improvement is the extraction of the `testRegexStateless` function into a dedicated utility module, which is then reused in multiple rules, reducing code duplication and improving maintainability. Additionally, comprehensive tests for this utility have been added.

**Utility extraction and reuse:**

* Extracted the `testRegexStateless` function into a new module (`test-regex-stateless.ts`) within `core/utils`, and updated `index.ts` to export it for use in other files. [[1]](diffhunk://#diff-c9b628dc51397a1001ad0a06f4066a5236063ede5ef74861814e4b73520808a9R1-R25) [[2]](diffhunk://#diff-149a28a90b23dd02407c2f42bbc85aebe746cbb71118e5cac4c17a2ac81cf47eR5-R13)
* Updated the rules `allow-heading`, `allow-image-url`, and `allow-link-url` to import and use the shared `testRegexStateless` utility instead of their own local implementations, and removed the duplicated helper code from these files. [[1]](diffhunk://#diff-fc8d30713d952bffeccd5e938b332f60474d26167270c16b9f511cda7f369087R13) [[2]](diffhunk://#diff-fc8d30713d952bffeccd5e938b332f60474d26167270c16b9f511cda7f369087L29-L30) [[3]](diffhunk://#diff-fc8d30713d952bffeccd5e938b332f60474d26167270c16b9f511cda7f369087L52-L63) [[4]](diffhunk://#diff-f0c45d42ca398155c9a8668f98a6f2403e937f915f61bad1dc4582aa2714996bL13-R13) [[5]](diffhunk://#diff-f0c45d42ca398155c9a8668f98a6f2403e937f915f61bad1dc4582aa2714996bL26-L43) [[6]](diffhunk://#diff-c2020f9d6c66e84127343f5ad0efdf7aa23d0f6a81fe52bfe8c738ab37a7bc64L13-R13) [[7]](diffhunk://#diff-c2020f9d6c66e84127343f5ad0efdf7aa23d0f6a81fe52bfe8c738ab37a7bc64L26-L43)

**Testing improvements:**

* Added a new test file `test-regex-stateless.test.ts` to provide comprehensive tests for the `testRegexStateless` utility, ensuring correct behavior and non-mutative operation on stateful regexes.