### PR TITLE
docs(eslint-markdown): update test file extensions

### DIFF
--- a/packages/eslint-markdown/src/core/utils/escape-string-regexp.test.ts
+++ b/packages/eslint-markdown/src/core/utils/escape-string-regexp.test.ts
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Test for `escape-string-regexp.js`
+ * @fileoverview Test for `escape-string-regexp.ts`
  * @see https://github.com/sindresorhus/escape-string-regexp/tree/v5.0.0
  */
 

--- a/packages/eslint-markdown/src/core/utils/html.test.ts
+++ b/packages/eslint-markdown/src/core/utils/html.test.ts
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Test for `html.js`
+ * @fileoverview Test for `html.ts`
  */
 
 // --------------------------------------------------------------------------------

--- a/packages/eslint-markdown/src/core/utils/is-blank-line.test.ts
+++ b/packages/eslint-markdown/src/core/utils/is-blank-line.test.ts
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Test for `is-blank-line.js`
+ * @fileoverview Test for `is-blank-line.ts`
  */
 
 // --------------------------------------------------------------------------------

--- a/packages/eslint-markdown/src/core/utils/skip-ranges.test.ts
+++ b/packages/eslint-markdown/src/core/utils/skip-ranges.test.ts
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Test for `skip-ranges.js`
+ * @fileoverview Test for `skip-ranges.ts`
  *
  * - The newline character (`\n`) is considered the last character of the current line.
  * - The newline character is always located at the end position (column) of the previous line,

--- a/packages/eslint-markdown/src/index.test-d.ts
+++ b/packages/eslint-markdown/src/index.test-d.ts
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Type test for `index.js`.
+ * @fileoverview Type test for `index.ts`.
  */
 
 /* eslint-disable -- Type test */

--- a/packages/eslint-markdown/src/index.test.ts
+++ b/packages/eslint-markdown/src/index.test.ts
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Test for `index.js`.
+ * @fileoverview Test for `index.ts`.
  * @author lumir(lumirlumir)
  */
 

--- a/packages/eslint-markdown/src/rules/allow-heading.test.ts
+++ b/packages/eslint-markdown/src/rules/allow-heading.test.ts
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Test for `allow-heading.js`.
+ * @fileoverview Test for `allow-heading.ts`.
  * @author lumir(lumirlumir)
  */
 

--- a/packages/eslint-markdown/src/rules/allow-image-url.test.ts
+++ b/packages/eslint-markdown/src/rules/allow-image-url.test.ts
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Test for `allow-image-url.js`.
+ * @fileoverview Test for `allow-image-url.ts`.
  * @author lumir(lumirlumir)
  * @see https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/blob/main/src/textlint-rule-allowed-uris.test.js
  */

--- a/packages/eslint-markdown/src/rules/allow-link-url.test.ts
+++ b/packages/eslint-markdown/src/rules/allow-link-url.test.ts
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Test for `allow-link-url.js`.
+ * @fileoverview Test for `allow-link-url.ts`.
  * @author lumir(lumirlumir)
  * @see https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/blob/main/src/textlint-rule-allowed-uris.test.js
  */

--- a/packages/eslint-markdown/src/rules/code-lang-shorthand.test.ts
+++ b/packages/eslint-markdown/src/rules/code-lang-shorthand.test.ts
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Test for `code-lang-shorthand.js`.
+ * @fileoverview Test for `code-lang-shorthand.ts`.
  * @author lumir(lumirlumir)
  */
 

--- a/packages/eslint-markdown/src/rules/consistent-code-style.test.ts
+++ b/packages/eslint-markdown/src/rules/consistent-code-style.test.ts
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Test for `consistent-code-style.js`.
+ * @fileoverview Test for `consistent-code-style.ts`.
  * @author lumir(lumirlumir)
  */
 

--- a/packages/eslint-markdown/src/rules/consistent-delete-style.test.ts
+++ b/packages/eslint-markdown/src/rules/consistent-delete-style.test.ts
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Test for `consistent-delete-style.js`.
+ * @fileoverview Test for `consistent-delete-style.ts`.
  * @author lumir(lumirlumir)
  */
 

--- a/packages/eslint-markdown/src/rules/consistent-emphasis-style.test.ts
+++ b/packages/eslint-markdown/src/rules/consistent-emphasis-style.test.ts
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Test for `consistent-emphasis-style.js`.
+ * @fileoverview Test for `consistent-emphasis-style.ts`.
  * @author lumir(lumirlumir)
  */
 

--- a/packages/eslint-markdown/src/rules/consistent-inline-code-style.test.ts
+++ b/packages/eslint-markdown/src/rules/consistent-inline-code-style.test.ts
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Test for `consistent-inline-code-style.js`.
+ * @fileoverview Test for `consistent-inline-code-style.ts`.
  * @author lumir(lumirlumir)
  * Note: All test cases have been verified against `markdownlint`'s MD038 rule.
  */

--- a/packages/eslint-markdown/src/rules/consistent-strong-style.test.ts
+++ b/packages/eslint-markdown/src/rules/consistent-strong-style.test.ts
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Test for `consistent-strong-style.js`.
+ * @fileoverview Test for `consistent-strong-style.ts`.
  * @author lumir(lumirlumir)
  */
 

--- a/packages/eslint-markdown/src/rules/consistent-thematic-break-style.test.ts
+++ b/packages/eslint-markdown/src/rules/consistent-thematic-break-style.test.ts
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Test for `consistent-thematic-break-style.js`.
+ * @fileoverview Test for `consistent-thematic-break-style.ts`.
  * @author lumir(lumirlumir)
  */
 

--- a/packages/eslint-markdown/src/rules/consistent-unordered-list-style.test.ts
+++ b/packages/eslint-markdown/src/rules/consistent-unordered-list-style.test.ts
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Test for `consistent-unordered-list-style.js`.
+ * @fileoverview Test for `consistent-unordered-list-style.ts`.
  * @author hyoban
  */
 

--- a/packages/eslint-markdown/src/rules/en-capitalization.test.ts
+++ b/packages/eslint-markdown/src/rules/en-capitalization.test.ts
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Test for `no-irregular-dash.js`.
+ * @fileoverview Test for `no-irregular-dash.ts`.
  * @author lumir(lumirlumir)
  */
 

--- a/packages/eslint-markdown/src/rules/en-capitalization.test.ts
+++ b/packages/eslint-markdown/src/rules/en-capitalization.test.ts
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Test for `no-irregular-dash.ts`.
+ * @fileoverview Test for `en-capitalization.ts`.
  * @author lumir(lumirlumir)
  */
 

--- a/packages/eslint-markdown/src/rules/no-bold-paragraph.test.ts
+++ b/packages/eslint-markdown/src/rules/no-bold-paragraph.test.ts
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Test for `no-bold-paragraph.js`.
+ * @fileoverview Test for `no-bold-paragraph.ts`.
  * @author lumir(lumirlumir)
  */
 

--- a/packages/eslint-markdown/src/rules/no-consecutive-blank-line.test.ts
+++ b/packages/eslint-markdown/src/rules/no-consecutive-blank-line.test.ts
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Test for `no-consecutive-blank-line.js`.
+ * @fileoverview Test for `no-consecutive-blank-line.ts`.
  * @author lumir(lumirlumir)
  * NOTE: All test cases have been verified against `markdownlint`.
  */

--- a/packages/eslint-markdown/src/rules/no-control-character.test.ts
+++ b/packages/eslint-markdown/src/rules/no-control-character.test.ts
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Test for `no-control-character.js`.
+ * @fileoverview Test for `no-control-character.ts`.
  * @author lumir(lumirlumir)
  */
 

--- a/packages/eslint-markdown/src/rules/no-curly-quote.test.ts
+++ b/packages/eslint-markdown/src/rules/no-curly-quote.test.ts
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Test for `no-curly-quote.js`.
+ * @fileoverview Test for `no-curly-quote.ts`.
  * @author lumir(lumirlumir)
  */
 

--- a/packages/eslint-markdown/src/rules/no-double-punctuation.test.ts
+++ b/packages/eslint-markdown/src/rules/no-double-punctuation.test.ts
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Test for `no-double-punctuation.js`.
+ * @fileoverview Test for `no-double-punctuation.ts`.
  * @author lumir(lumirlumir)
  */
 

--- a/packages/eslint-markdown/src/rules/no-double-space.test.ts
+++ b/packages/eslint-markdown/src/rules/no-double-space.test.ts
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Test for `no-double-space.js`.
+ * @fileoverview Test for `no-double-space.ts`.
  * @author lumir(lumirlumir)
  */
 

--- a/packages/eslint-markdown/src/rules/no-emoji.test.ts
+++ b/packages/eslint-markdown/src/rules/no-emoji.test.ts
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Test for `no-emoji.js`.
+ * @fileoverview Test for `no-emoji.ts`.
  * @author lumir(lumirlumir)
  */
 

--- a/packages/eslint-markdown/src/rules/no-git-conflict-marker.test.ts
+++ b/packages/eslint-markdown/src/rules/no-git-conflict-marker.test.ts
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Test for `no-git-conflict-marker.js`.
+ * @fileoverview Test for `no-git-conflict-marker.ts`.
  * @author lumir(lumirlumir)
  */
 

--- a/packages/eslint-markdown/src/rules/no-irregular-dash.test.ts
+++ b/packages/eslint-markdown/src/rules/no-irregular-dash.test.ts
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Test for `no-irregular-dash.js`.
+ * @fileoverview Test for `no-irregular-dash.ts`.
  * @author lumir(lumirlumir)
  */
 

--- a/packages/eslint-markdown/src/rules/no-irregular-whitespace.test.ts
+++ b/packages/eslint-markdown/src/rules/no-irregular-whitespace.test.ts
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Test for `no-irregular-whitespace.js`.
+ * @fileoverview Test for `no-irregular-whitespace.ts`.
  * @author lumir(lumirlumir)
  */
 

--- a/packages/eslint-markdown/src/rules/no-tab.test.ts
+++ b/packages/eslint-markdown/src/rules/no-tab.test.ts
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Test for `no-tab.js`.
+ * @fileoverview Test for `no-tab.ts`.
  * @author lumir(lumirlumir)
  */
 

--- a/packages/eslint-markdown/src/rules/no-url-trailing-slash.test.ts
+++ b/packages/eslint-markdown/src/rules/no-url-trailing-slash.test.ts
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Test for `no-url-trailing-slash.js`.
+ * @fileoverview Test for `no-url-trailing-slash.ts`.
  * @author lumir(lumirlumir)
  */
 

--- a/packages/eslint-markdown/src/rules/require-heading-id.test.ts
+++ b/packages/eslint-markdown/src/rules/require-heading-id.test.ts
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Test for `require-heading-id.js`.
+ * @fileoverview Test for `require-heading-id.ts`.
  * @author lumir(lumirlumir)
  */
 

--- a/packages/eslint-markdown/src/rules/require-image-title.test.ts
+++ b/packages/eslint-markdown/src/rules/require-image-title.test.ts
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Test for `require-image-title.js`.
+ * @fileoverview Test for `require-image-title.ts`.
  * @author lumir(lumirlumir)
  */
 

--- a/packages/eslint-markdown/src/rules/require-link-title.test.ts
+++ b/packages/eslint-markdown/src/rules/require-link-title.test.ts
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Test for `require-link-title.js`.
+ * @fileoverview Test for `require-link-title.ts`.
  * @author lumir(lumirlumir)
  */
 


### PR DESCRIPTION
## Summary

- Update test file overview comments to reference the current `.ts` source files instead of `.js` files.

## Scope

- `packages/eslint-markdown/src/index.test.ts`
- `packages/eslint-markdown/src/index.test-d.ts`
- Test files under `packages/eslint-markdown/src/core/utils/` and `packages/eslint-markdown/src/rules/`

## Validation

- `npm run test` (1,970 tests passed)
- `npm run build`
- `npm run lint`
- `git diff --check`

## Notes

- Comment-only change with no runtime behavior impact.