### PR TITLE
chore(release): bump package versions from `v0.12.0` to `v0.12.1` (`patch`)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "npm-eslint-markdown",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "npm-eslint-markdown",
-      "version": "0.12.0",
+      "version": "0.12.1",
       "workspaces": [
         "packages/*",
         "website"
@@ -9966,7 +9966,7 @@
       }
     },
     "packages/eslint-markdown": {
-      "version": "0.12.0",
+      "version": "0.12.1",
       "license": "MIT",
       "dependencies": {
         "@eslint/markdown": "^7.5.1",
@@ -10006,7 +10006,7 @@
         "@codecov/bundler-plugin-core": "^2.0.1",
         "@shikijs/transformers": "^3.20.0",
         "@shikijs/vitepress-twoslash": "^3.20.0",
-        "eslint-markdown": "^0.12.0",
+        "eslint-markdown": "^0.12.1",
         "twoslash-eslint": "^0.3.4",
         "unplugin": "^1.16.1",
         "vitepress": "2.0.0-alpha.17",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "npm-eslint-markdown",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "type": "module",
   "packageManager": "npm@10.9.2",
   "engines": {

--- a/packages/eslint-markdown/package.json
+++ b/packages/eslint-markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-markdown",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "type": "module",
   "sideEffects": false,
   "description": "Lint your Markdown with ESLint. Additional rules for use with `@eslint/markdown`.🛠️",

--- a/website/package.json
+++ b/website/package.json
@@ -11,7 +11,7 @@
     "@codecov/bundler-plugin-core": "^2.0.1",
     "@shikijs/transformers": "^3.20.0",
     "@shikijs/vitepress-twoslash": "^3.20.0",
-    "eslint-markdown": "^0.12.0",
+    "eslint-markdown": "^0.12.1",
     "twoslash-eslint": "^0.3.4",
     "unplugin": "^1.16.1",
     "vitepress": "2.0.0-alpha.17",


### PR DESCRIPTION
## Release Information: `v0.12.1`

New release of `lumirlumir/npm-eslint-markdown` has arrived! :tada:

This PR bumps the package versions from `v0.12.0` to `v0.12.1` (`patch`).

See [Actions](https://github.com/lumirlumir/npm-eslint-markdown/actions/runs/29130457790) for more details.

| Info        | Value                      |
| ----------- | -------------------------- |
| Repository  | `lumirlumir/npm-eslint-markdown` |
| SEMVER      | `patch`     |
| Pre ID      | `canary`      |
| Short SHA   | cbbe95f       |
| Old Version | `v0.12.0`  |
| New Version | `v0.12.1`  |

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### :bug: Bug Fixes
* fix(eslint-markdown): handle stateful regex for `allow-image-url` by @lumirlumir in https://github.com/lumirlumir/npm-eslint-markdown/pull/615
* fix(eslint-markdown): handle stateful regex for `allow-link-url` by @lumirlumir in https://github.com/lumirlumir/npm-eslint-markdown/pull/617
### :memo: Documentation
* docs(eslint-markdown): update test file extensions by @lumirlumir in https://github.com/lumirlumir/npm-eslint-markdown/pull/619
### :recycle: Code Refactoring
* refactor(eslint-markdown): extract stateless regex test utility by @lumirlumir in https://github.com/lumirlumir/npm-eslint-markdown/pull/618
### :arrow_up: Dependency Updates
* chore(deps-dev): bump prettier from 3.9.4 to 3.9.5 in the dev-dependencies group across 1 directory by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-markdown/pull/616


**Full Changelog**: https://github.com/lumirlumir/npm-eslint-markdown/compare/v0.12.0...v0.12.1