### PR TITLE
fix(eslint-markdown)!: enforce strict schema for style option in `consistent-thematic-break-style`

### DIFF
--- a/packages/eslint-markdown/src/rules/consistent-thematic-break-style.test.ts
+++ b/packages/eslint-markdown/src/rules/consistent-thematic-break-style.test.ts
@@ -223,7 +223,6 @@ ruleTester('consistent-thematic-break-style', rule, {
         },
       ],
     },
-
     {
       name: '`--- ` style',
       code: '--- \n\n***',
@@ -256,6 +255,31 @@ ruleTester('consistent-thematic-break-style', rule, {
         },
       ],
     },
+    {
+      name: '`_ _ _` style',
+      code: '---\n\n***',
+      output: '_ _ _\n\n_ _ _',
+      options: [{ style: '_ _ _' }],
+      errors: [
+        {
+          messageId: 'style',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 4,
+          data: { style: '_ _ _' },
+        },
+        {
+          messageId: 'style',
+          line: 3,
+          column: 1,
+          endLine: 3,
+          endColumn: 4,
+          data: { style: '_ _ _' },
+        },
+      ],
+    },
+
     // Blockquote
     {
       name: 'Blockquote - `consistent` style',

--- a/packages/eslint-markdown/src/rules/consistent-thematic-break-style.test.ts
+++ b/packages/eslint-markdown/src/rules/consistent-thematic-break-style.test.ts
@@ -32,6 +32,16 @@ ruleTester('consistent-thematic-break-style', rule, {
       name: '`consistent` style - 2',
       code: '---\n\n---\n\n---',
     },
+    {
+      name: '`--- ` style with trailing spaces',
+      code: '--- \n\n--- ',
+      options: [{ style: '--- ' }],
+    },
+    {
+      name: '`-\t-\t-` style with tabs',
+      code: '-\t-\t-\n\n-\t-\t-',
+      options: [{ style: '-\t-\t-' }],
+    },
   ],
 
   invalid: [
@@ -214,6 +224,38 @@ ruleTester('consistent-thematic-break-style', rule, {
       ],
     },
 
+    {
+      name: '`--- ` style',
+      code: '--- \n\n***',
+      output: '--- \n\n--- ',
+      options: [{ style: '--- ' }],
+      errors: [
+        {
+          messageId: 'style',
+          line: 3,
+          column: 1,
+          endLine: 3,
+          endColumn: 4,
+          data: { style: '--- ' },
+        },
+      ],
+    },
+    {
+      name: '`-\t-\t-` style',
+      code: '-\t-\t-\n\n***',
+      output: '-\t-\t-\n\n-\t-\t-',
+      options: [{ style: '-\t-\t-' }],
+      errors: [
+        {
+          messageId: 'style',
+          line: 3,
+          column: 1,
+          endLine: 3,
+          endColumn: 4,
+          data: { style: '-\t-\t-' },
+        },
+      ],
+    },
     // Blockquote
     {
       name: 'Blockquote - `consistent` style',

--- a/packages/eslint-markdown/src/rules/consistent-thematic-break-style.ts
+++ b/packages/eslint-markdown/src/rules/consistent-thematic-break-style.ts
@@ -18,6 +18,18 @@ type RuleOptions = [{ style: string }];
 type MessageIds = 'style';
 
 // --------------------------------------------------------------------------------
+// Helper
+// --------------------------------------------------------------------------------
+
+/**
+ * Matches `consistent` or a valid CommonMark thematic break style
+ * (3+ identical `-`, `*`, or `_` characters, each optionally followed by spaces/tabs).
+ * @see https://spec.commonmark.org/0.31.2/#thematic-breaks
+ */
+const thematicBreakStylePattern =
+  '^(?:consistent|(?:-[ \\t]*){3,}|(?:\\*[ \\t]*){3,}|(?:_[ \\t]*){3,})$';
+
+// --------------------------------------------------------------------------------
 // Rule Definition
 // --------------------------------------------------------------------------------
 
@@ -40,6 +52,7 @@ export default {
         properties: {
           style: {
             type: 'string',
+            pattern: thematicBreakStylePattern,
           },
         },
         additionalProperties: false,

--- a/website/docs/rules/consistent-thematic-break-style.md
+++ b/website/docs/rules/consistent-thematic-break-style.md
@@ -112,7 +112,7 @@ ___
 
 When `style` is set to `'consistent'`, the rule enforces that all thematic breaks in the document use the same style as the first one encountered.
 
-You can also specify a particular style by setting style to `'---'`, `'***'`, `'___'`, or any other `string` value, which will enforce that all thematic breaks use the specified style.
+You can also specify a particular style by setting style to `'---'`, `'***'`, `'___'`, or any other valid thematic break, which will enforce that all thematic breaks use the specified style. A valid thematic break is a sequence of three or more matching `-`, `*`, or `_` characters, each optionally followed by any number of spaces or tabs.
 
 ## Fix
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  Be sure to check our contributing guidelines in the `README.md` or `CONTRIBUTING.md` before opening a pull request.
-->

## Summary
The `style` option of `consistent-thematic-break-style` only declared `type: 'string'`, so any string was accepted. Values such as `a` or `$$$` passed validation, and the fixer replaced every thematic break with text that Markdown renders as a paragraph instead of an `<hr>`.

This pull request adds a schema pattern that accepts only valid CommonMark thematic breaks.

<!--
  Explain the motivation for making this change. What existing problem does the pull request solve?
-->

## Details
- Add a `pattern` to the `style` option so it accepts `consistent` or a valid CommonMark thematic break.
- Allow three or more matching `-`, `*`, or `_` characters, each optionally followed by any number of spaces or tabs.
- Exclude leading indentation, since the fixer replaces only the thematic break itself and an indented value would stack indentation into a code block.
- Update the `style` option description on the documentation site, which previously said any `string` value was accepted.
- Add `style` option test cases for `-`, `*`, and `_` styles and for values containing spaces or tabs.

### References

The following files were reviewed for repository conventions:

- [`no-double-punctuation`](https://github.com/lumirlumir/npm-eslint-markdown/blob/main/packages/eslint-markdown/src/rules/no-double-punctuation.ts): schema `pattern` conventions
- [`consistent-emphasis-style`](https://github.com/lumirlumir/npm-eslint-markdown/blob/main/website/docs/rules/consistent-emphasis-style.md), [`consistent-code-style`](https://github.com/lumirlumir/npm-eslint-markdown/blob/main/website/docs/rules/consistent-code-style.md), [`consistent-unordered-list-style`](https://github.com/lumirlumir/npm-eslint-markdown/blob/main/website/docs/rules/consistent-unordered-list-style.md): `style` option documentation wording

### Notes on trailing spaces and tabs

Styles such as `'--- '` are accepted because the CommonMark specification allows spaces or tabs after each character. Such a thematic break still renders as `<hr>`.

### Breaking change

Configurations that set `style` to a value that is not a valid thematic break now fail schema validation.

<!--
  Explain the details you made on this pull request.
  The more detailed it is, the more likely it will be approved.
-->

## How did you test this change?

- `npm run test`
  - All 1983 tests passed, including 10 new tests for `consistent-thematic-break-style`.
- `npm run lint`
- `npm run build`

All commands completed successfully.

Invalid option values are rejected by the schema:

```
// { style: '$$$' }
Error: Key "rules": Key "md/consistent-thematic-break-style":
        Value "$$$" should match pattern "^(?:consistent|(?:-[ \t]*){3,}|(?:\*[ \t]*){3,}|(?:_[ \t]*){3,})$".

// { style: 'a' }
Error: Key "rules": Key "md/consistent-thematic-break-style":
        Value "a" should match pattern "^(?:consistent|(?:-[ \t]*){3,}|(?:\*[ \t]*){3,}|(?:_[ \t]*){3,})$".

// { style: '-abcdefg-' }
Error: Key "rules": Key "md/consistent-thematic-break-style":
        Value "-abcdefg-" should match pattern "^(?:consistent|(?:-[ \t]*){3,}|(?:\*[ \t]*){3,}|(?:_[ \t]*){3,})$".
```


<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots or videos.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

## Resolved Issues

Closes #637
<!--
  If you fixed problems in issues, write down the numbers of issues.
  Example: #1, #2, ...
-->

## Checklist

- [x] I have read the [**code of conduct**](https://github.com/lumirlumir/.github/blob/main/CODE_OF_CONDUCT.md) and **contributing guidelines** in the repository root.
