### PR TITLE
chore(release): bump package versions from `v0.12.1` to `v0.13.0` (`minor`)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "npm-eslint-markdown",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "npm-eslint-markdown",
-      "version": "0.12.1",
+      "version": "0.13.0",
       "workspaces": [
         "packages/*",
         "website"
@@ -9989,7 +9989,7 @@
       }
     },
     "packages/eslint-markdown": {
-      "version": "0.12.1",
+      "version": "0.13.0",
       "license": "MIT",
       "dependencies": {
         "@eslint/markdown": "^7.5.1",
@@ -10029,7 +10029,7 @@
         "@codecov/bundler-plugin-core": "^2.0.1",
         "@shikijs/transformers": "^3.20.0",
         "@shikijs/vitepress-twoslash": "^3.20.0",
-        "eslint-markdown": "^0.12.1",
+        "eslint-markdown": "^0.13.0",
         "twoslash-eslint": "^0.3.4",
         "unplugin": "^1.16.1",
         "vitepress": "2.0.0-alpha.17",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "npm-eslint-markdown",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "type": "module",
   "packageManager": "npm@10.9.2",
   "engines": {

--- a/packages/eslint-markdown/package.json
+++ b/packages/eslint-markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-markdown",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "type": "module",
   "sideEffects": false,
   "description": "Lint your Markdown with ESLint. Additional rules for use with `@eslint/markdown`.🛠️",

--- a/website/package.json
+++ b/website/package.json
@@ -11,7 +11,7 @@
     "@codecov/bundler-plugin-core": "^2.0.1",
     "@shikijs/transformers": "^3.20.0",
     "@shikijs/vitepress-twoslash": "^3.20.0",
-    "eslint-markdown": "^0.12.1",
+    "eslint-markdown": "^0.13.0",
     "twoslash-eslint": "^0.3.4",
     "unplugin": "^1.16.1",
     "vitepress": "2.0.0-alpha.17",


### PR DESCRIPTION
## Release Information: `v0.13.0`

New release of `lumirlumir/npm-eslint-markdown` has arrived! :tada:

This PR bumps the package versions from `v0.12.1` to `v0.13.0` (`minor`).

See [Actions](https://github.com/lumirlumir/npm-eslint-markdown/actions/runs/30923194132) for more details.

| Info        | Value                      |
| ----------- | -------------------------- |
| Repository  | `lumirlumir/npm-eslint-markdown` |
| SEMVER      | `minor`     |
| Pre ID      | `canary`      |
| Short SHA   | 8b10448       |
| Old Version | `v0.12.1`  |
| New Version | `v0.13.0`  |

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### :boom: BREAKING CHANGES
* fix(eslint-markdown)!: enforce strict schema for style option in `consistent-thematic-break-style` by @tooth-is-silver in https://github.com/lumirlumir/npm-eslint-markdown/pull/639
* feat(eslint-markdown)!: add `no-trailing-heading-punctuation` rule by @tooth-is-silver in https://github.com/lumirlumir/npm-eslint-markdown/pull/632
### :toolbox: Chores
* chore(sync-server): bump actions/setup-node from 6 to 7 by @lumirlumir in https://github.com/lumirlumir/npm-eslint-markdown/pull/633
### :arrow_up: Dependency Updates
* chore(deps-dev): bump the dev-dependencies group across 2 directories with 1 update by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-markdown/pull/621
* chore(deps-dev): bump eslint-config-bananass from 0.7.0 to 0.8.0 in the dev-dependencies group across 1 directory by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-markdown/pull/624
* chore(deps-dev): bump prettier from 3.9.5 to 3.9.6 in the dev-dependencies group across 1 directory by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-markdown/pull/631
* chore(deps): bump linkify-it from 5.0.1 to 5.0.2 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-markdown/pull/634
* chore(deps-dev): bump shell-quote from 1.8.4 to 1.10.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-markdown/pull/635
* chore(deps-dev): bump the dev-dependencies group across 2 directories with 1 update by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-markdown/pull/636

## New Contributors
* @tooth-is-silver made their first contribution in https://github.com/lumirlumir/npm-eslint-markdown/pull/639

**Full Changelog**: https://github.com/lumirlumir/npm-eslint-markdown/compare/v0.12.1...v0.13.0