### PR TITLE
chore(*): configure linting for local type tests and update `package.json`

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -28,6 +28,16 @@ export default defineConfig([
       'import/no-extraneous-dependencies': 'off', // Too computationally expensive. TODO: Remove this in shared config.
     },
   },
+  {
+    name: 'js/global/test-d',
+    files: ['**/*.test-d.{ts,mts,cts,tsx}'],
+    rules: {
+      'no-useless-assignment': 'off',
+      'prefer-const': 'off',
+      '@typescript-eslint/no-unsafe-function-type': 'off',
+      '@typescript-eslint/no-unused-vars': 'off',
+    },
+  },
 
   // md
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "editorconfig-checker": "^6.1.1",
         "eslint": "^9.39.5",
         "eslint-config-bananass": "^0.8.0",
-        "eslint-markdown": "^0.11.0",
+        "eslint-markdown": "file:packages/eslint-markdown",
         "husky": "^9.1.7",
         "lint-staged": "^16.4.0",
         "markdownlint-cli": "^0.48.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "editorconfig-checker": "^6.1.1",
     "eslint": "^9.39.5",
     "eslint-config-bananass": "^0.8.0",
-    "eslint-markdown": "^0.11.0",
+    "eslint-markdown": "file:packages/eslint-markdown",
     "husky": "^9.1.7",
     "lint-staged": "^16.4.0",
     "markdownlint-cli": "^0.48.0",


### PR DESCRIPTION
This pull request introduces a new ESLint override for test declaration files and updates the `eslint-markdown` dependency to use a local package. These changes help tailor linting behavior for specific file types and prepare the codebase for local development or custom rules.

**ESLint configuration updates:**

* Added a new configuration block in `eslint.config.js` to disable several rules (such as `no-useless-assignment`, `prefer-const`, `@typescript-eslint/no-unsafe-function-type`, and `@typescript-eslint/no-unused-vars`) for files matching `**/*.test-d.{ts,mts,cts,tsx}`. This ensures that test declaration files are not subject to unnecessary or overly strict linting.

**Dependency management:**

* Changed the `eslint-markdown` dependency in `package.json` to use a local package (`file:packages/eslint-markdown`) instead of the published version, likely for development or customization purposes.